### PR TITLE
Speedup the scan of any kind of rules

### DIFF
--- a/lib/goodcheck/analyzer.rb
+++ b/lib/goodcheck/analyzer.rb
@@ -33,8 +33,10 @@ module Goodcheck
               text = scanner.matched
               affected_rules = affected_rules(rule, text)
               range = (scanner.pos - text.bytesize) .. scanner.pos
-              affected_rules.each do |rule|
-                issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+              unless issues.any? {|issue| issue.range == range }
+                affected_rules.each do |rule|
+                  issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+                end
               end
             when scanner.scan(/.\b/m)
               after_break = true

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -19,10 +19,10 @@ module Goodcheck
 
       def run
         reporter.analysis do
-          load_config!
+          config = load_config!
           each_check do |buffer, rule|
             reporter.rule(rule) do
-              analyzer = Analyzer.new(rule: rule, buffer: buffer)
+              analyzer = Analyzer.new(rule: rule, buffer: buffer, rules: config.rules)
               analyzer.scan do |issue|
                 reporter.issue(issue)
               end

--- a/lib/goodcheck/commands/test.rb
+++ b/lib/goodcheck/commands/test.rb
@@ -87,7 +87,7 @@ module Goodcheck
 
       def rule_matches_example?(rule, example)
         buffer = Buffer.new(path: Pathname("-"), content: example)
-        analyzer = Analyzer.new(rule: rule, buffer: buffer)
+        analyzer = Analyzer.new(rule: rule, buffer: buffer, rules: config.rules)
         analyzer.scan.count > 0
       end
     end

--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -6,20 +6,33 @@ module Goodcheck
       @rules = rules
     end
 
+    def build_global_regexp(rules_filter:)
+      if rules_filter.empty?
+        Regexp.union(rules.map(&:patterns).compact.flatten.map(&:regexp))
+      else
+        filtered_rules = rules.select do |rule|
+          rules_filter.any? { |filter| /\A#{Regexp.escape(filter)}\.?/ =~ rule.id }
+        end
+        Regexp.union(filtered_rules.map(&:patterns).compact.flatten.map(&:regexp))
+      end
+    end
+
     def rules_for_path(path, rules_filter:, &block)
       if block_given?
-        rules.map do |rule|
-          if rules_filter.empty? || rules_filter.any? {|filter| /\A#{Regexp.escape(filter)}\.?/ =~ rule.id }
-            if rule.globs.empty?
-              [rule, nil]
-            else
-              glob = rule.globs.find {|glob| path.fnmatch?(glob.pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
-              if glob
-                [rule, glob]
-              end
-            end
-          end
-        end.compact.each(&block)
+        # if rules_filter.empty? || rules_filter.any? { |filter| /\A#{Regexp.escape(filter)}\.?/ =~ rule.id }
+        all_globs = rules.map(&:globs).flatten
+        global_regexp = build_global_regexp(rules_filter: rules_filter)
+       
+        ### Create an effective rule with global_regexp as its pattern
+        eff_rule = Rule.new(id: 'effective_rule',
+                            patterns: [Pattern.regexp(global_regexp, case_sensitive: false, multiline: false)],
+                            message: 'effective rule',
+                            justifications: '',
+                            globs: all_globs,
+                            fails: nil,
+                            passes: nil)
+        glob = eff_rule.globs.find { |gl| path.fnmatch?(gl.pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
+        [[eff_rule, glob]].compact.each(&block) if glob
       else
         enum_for(:rules_for_path, path, rules_filter: rules_filter)
       end

--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -21,8 +21,8 @@ module Goodcheck
       if block_given?
         # if rules_filter.empty? || rules_filter.any? { |filter| /\A#{Regexp.escape(filter)}\.?/ =~ rule.id }
         all_globs = rules.map(&:globs).flatten
+        all_globs = nil if all_globs.empty?
         global_regexp = build_global_regexp(rules_filter: rules_filter)
-       
         ### Create an effective rule with global_regexp as its pattern
         eff_rule = Rule.new(id: 'effective_rule',
                             patterns: [Pattern.regexp(global_regexp, case_sensitive: false, multiline: false)],
@@ -31,8 +31,14 @@ module Goodcheck
                             globs: all_globs,
                             fails: nil,
                             passes: nil)
-        glob = eff_rule.globs.find { |gl| path.fnmatch?(gl.pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
-        [[eff_rule, glob]].compact.each(&block) if glob
+        if all_globs
+          glob = eff_rule.globs.find { |gl| path.fnmatch?(gl.pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
+        end
+        if glob
+          [[eff_rule, glob]].compact.each(&block)
+        else
+          [[eff_rule, nil]].compact.each(&block)
+        end
       else
         enum_for(:rules_for_path, path, rules_filter: rules_filter)
       end

--- a/lib/goodcheck/pattern.rb
+++ b/lib/goodcheck/pattern.rb
@@ -17,7 +17,11 @@ module Goodcheck
       options |= Regexp::IGNORECASE unless case_sensitive
       options |= Regexp::MULTILINE if multiline
 
-      new(source: regexp, regexp: Regexp.compile(regexp, options))
+      if regexp.is_a? String
+        new(source: regexp, regexp: Regexp.compile(regexp, options))
+      else
+        new(source: regexp, regexp: Regexp.compile(regexp))
+      end
     end
 
     def self.token(tokens, case_sensitive:)

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -25,7 +25,8 @@ NSArray *a = [ NSMutableArray
   end
 
   def test_analyzer
-    analyzer = Analyzer.new(buffer: buffer, rule: new_rule("rule1", Pattern.literal("ipsum", case_sensitive: true)))
+    rule = new_rule("rule1", Pattern.literal("ipsum", case_sensitive: true))
+    analyzer = Analyzer.new(buffer: buffer, rule: rule, rules: [rule])
 
     issues = analyzer.scan.to_a
 
@@ -35,7 +36,8 @@ NSArray *a = [ NSMutableArray
   end
 
   def test_analyzer_japanese
-    analyzer = Analyzer.new(buffer: buffer, rule: new_rule("rule1", Pattern.literal("吾輩", case_sensitive: true)))
+    rule = new_rule("rule1", Pattern.literal("吾輩", case_sensitive: true))
+    analyzer = Analyzer.new(buffer: buffer, rule: rule, rules: [rule])
 
     issues = analyzer.scan.to_a
 
@@ -45,7 +47,8 @@ NSArray *a = [ NSMutableArray
   end
 
   def test_analyzer_tokens
-    analyzer = Analyzer.new(buffer: buffer, rule: new_rule("rule1", Pattern.token("[NSMutableArray new]", case_sensitive: true)))
+    rule = new_rule("rule1", Pattern.token("[NSMutableArray new]", case_sensitive: true))
+    analyzer = Analyzer.new(buffer: buffer, rule: rule, rules: [rule])
 
     issues = analyzer.scan.to_a
 
@@ -56,21 +59,21 @@ NSArray *a = [ NSMutableArray
   end
 
   def test_analyzer_no_duplicate
-    analyzer = Analyzer.new(buffer: buffer, rule:
-      new_rule("rule1",
-               Pattern.regexp("N.Array", case_sensitive: false, multiline: false),
-               Pattern.regexp("NSAr.ay", case_sensitive: false, multiline: false))
-    )
+    rule = new_rule("rule1",
+                    Pattern.regexp("N.Array", case_sensitive: false, multiline: false),
+                    Pattern.regexp("NSAr.ay", case_sensitive: false, multiline: false))
+    analyzer = Analyzer.new(buffer: buffer, rule: rule, rules: [rule])
 
     issues = analyzer.scan.to_a
 
-    assert_equal ["rule1"], issues.map(&:rule).map(&:id)
+    assert_equal ['rule1'], issues.map(&:rule).map(&:id)
     assert_equal ["NSArray"], issues.map(&:text)
     assert_equal [Location.new(start_line: 6, start_column: 0, end_line: 6, end_column: 7)], issues.map(&:location)
   end
 
   def test_analyzer_token_word_brake
-    analyzer = Analyzer.new(buffer: buffer, rule: new_rule("rule1", Pattern.token("Array", case_sensitive: true)))
+    rule = new_rule("rule1", Pattern.token("Array", case_sensitive: true))
+    analyzer = Analyzer.new(buffer: buffer, rule: rule, rules: [rule])
 
     issues = analyzer.scan.to_a
     assert_empty issues

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -18,10 +18,10 @@ class ConfigTest < Minitest::Test
       loader.load_rule({ id: "rule4", glob: ["**/*.ts{,x}"], message: "" })
     ])
 
-    assert_equal ["rule1", "rule2"], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
-    assert_equal ["rule1", "rule3"], config.rules_for_path(Pathname("app/models/user.rb"), rules_filter: []).map(&:first).map(&:id)
-    assert_equal ["rule2"], config.rules_for_path(Pathname("app/views/users/index.html.erb"), rules_filter: []).map(&:first).map(&:id)
-    assert_equal ["rule4"], config.rules_for_path(Pathname("frontend/src/foo.tsx"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("app/models/user.rb"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("app/views/users/index.html.erb"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("frontend/src/foo.tsx"), rules_filter: []).map(&:first).map(&:id)
   end
 
   def test_rules_for_path_glob_empty
@@ -31,7 +31,7 @@ class ConfigTest < Minitest::Test
       loader.load_rule({ id: "rule1", glob: [], message: "" }),
     ])
 
-    assert_equal ["rule1"], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
   end
 
   def test_rules_for_filter
@@ -43,6 +43,6 @@ class ConfigTest < Minitest::Test
       loader.load_rule({ id: "rule2", glob: [], message: "" }),
     ])
 
-    assert_equal ["rule1", "rule1.x"], config.rules_for_path(Pathname("bar.rb"), rules_filter: ["rule1"]).map(&:first).map(&:id)
+    assert_equal ['effective_rule'], config.rules_for_path(Pathname("bar.rb"), rules_filter: ["rule1"]).map(&:first).map(&:id)
   end
 end


### PR DESCRIPTION
Goodcheck performance decreases dramatically once we add more
than few rules.  This is because we are processing each
target file many times: one time per each rule.

Performance improves significantly if we build an effective
rule, with a pattern regexp being the union of all the
rules patterns.

Thereby, we process each target file just once.
For each match, collect all rules associated with it
and report to the user those rule messages.

In my machine, I observe following performance improvements:
~ 200% for ~ 5 rules,
~ 400% for ~ 15 rules,
~ 500% for ~ 30 rules.
~ 650% for ~ 45 rules.