### PR TITLE
Do not load dotfiles by default if glob is nil

### DIFF
--- a/lib/goodcheck/cli.rb
+++ b/lib/goodcheck/cli.rb
@@ -54,7 +54,9 @@ module Goodcheck
       end.parse!(args)
 
       if args.empty?
-        targets << Pathname(".")
+        Dir.glob("**/*").select do |fname|
+          Pathname(fname).file? && !Pathname(fname).symlink?
+          end.map { |arg| targets.push Pathname(arg) }
       else
         targets.push *args.map {|arg| Pathname(arg) }
       end


### PR DESCRIPTION
If the user desn't provide files neither in the
command line nor the YAML configuration file, then
Goodcheck skips dotfiles (Fix Issue#20).