### PR TITLE
Improve CLI help for `--formatter` option of `check` command

### DIFF
--- a/lib/goodcheck/cli.rb
+++ b/lib/goodcheck/cli.rb
@@ -48,7 +48,7 @@ module Goodcheck
         opts.on("-R RULE", "--rule=RULE") do |rule|
           rules << rule
         end
-        opts.on("--format=FORMAT") do |f|
+        opts.on("--format=<text|json> [default: 'text']") do |f|
           format = f
         end
       end.parse!(args)


### PR DESCRIPTION
More user-friendly description.

### Before

```
$ goodcheck check -h
Usage: goodcheck check [options] dirs...
    -c, --config=CONFIG
    -R, --rule=RULE
        --format=FORMAT
```

### After

```
$ bundle exec ./exe/goodcheck check -h
Usage: goodcheck check [options] dirs...
    -c, --config=CONFIG
    -R, --rule=RULE
        --format=<text|json> [default: 'text']
```