### PR TITLE
Exit with 2 when it finds matching text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Exit with `2` when it find matching text #27
 * Import rules from another location #26
 
 ## 1.3.1 (2018-08-16)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ Available options are:
 * `--debug` to print all debug messages.
 * `--force` to ignore downloaded caches
 
+`goodcheck check` exits with:
+ 
+* `0` when it does not find any matching text fragment
+* `2` when it finds some matching text
+* `1` when it finds some error
+
+You can check its exit status to identify if the tool find some pattern or not.
+
 ### `goodcheck test [options]`
 
 The `test` command tests rules.

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -23,18 +23,22 @@ module Goodcheck
       end
 
       def run
+        issue_reported = false
+
         reporter.analysis do
           load_config!(force_download: force_download, cache_path: cache_dir_path)
           each_check do |buffer, rule|
             reporter.rule(rule) do
               analyzer = Analyzer.new(rule: rule, buffer: buffer)
               analyzer.scan do |issue|
+                issue_reported = true
                 reporter.issue(issue)
               end
             end
           end
         end
-        0
+
+        issue_reported ? 2 : 0
       rescue Psych::Exception => exn
         stderr.puts "Unexpected error happens while loading YAML file: #{exn.inspect}"
         exn.backtrace.each do |trace_loc|

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -33,7 +33,7 @@ EOF
         reporter = Reporters::Text.new(stdout: stdout)
         check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
-        assert_equal 0, check.run
+        assert_equal 2, check.run
 
         refute_match %r(app/models/user\.rb:1:class User < ApplicationRecord), stdout.string
         assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout.string
@@ -61,7 +61,7 @@ EOF
         reporter = Reporters::Text.new(stdout: stdout)
         check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
-        assert_equal 0, check.run
+        assert_equal 2, check.run
 
         assert_match %r(test\.yml:1:text: Github), stdout.string
         refute_match %r(link\.yml:1:text: Github), stdout.string
@@ -91,7 +91,7 @@ EOF
         reporter = Reporters::Text.new(stdout: stdout)
         check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
-        assert_equal 0, check.run
+        assert_equal 2, check.run
       end
     end
   end
@@ -135,6 +135,24 @@ EOF
     end
   end
 
+  def test_no_match
+    TestCaseBuilder.tmpdir do |builder|
+      builder.config content: <<EOF
+rules:
+  - id: foo
+    message: Foo
+    pattern: foo
+EOF
+
+      builder.cd do
+        reporter = Reporters::Text.new(stdout: stdout)
+        check = Check.new(config_path: builder.config_path.basename, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
+
+        assert_equal 0, check.run
+      end
+    end
+  end
+
   def test_encoding
     TestCaseBuilder.tmpdir do |builder|
       builder.config content: <<EOF
@@ -160,7 +178,7 @@ EOF
         reporter = Reporters::Text.new(stdout: stdout)
         check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
-        assert_equal 0, check.run
+        assert_equal 2, check.run
 
         assert_match %r(euc-jp:1:吾輩は猫である。), stdout.string
         assert_match %r(utf-8:1:吾輩は猫である。), stdout.string
@@ -184,7 +202,7 @@ EOF
         reporter = Reporters::Text.new(stdout: stdout)
         check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
-        assert_equal 0, check.run
+        assert_equal 2, check.run
 
         assert_match %r(binary_file: #<ArgumentError: invalid byte sequence in UTF-8>), stderr.string
         assert_match %r(text_file:1:猫ねこ🐈:\tFoo), stdout.string
@@ -218,14 +236,14 @@ rules:
 EOF
 
         Check.new(config_path: builder.config_path.basename, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
-          assert_equal 0, check.run
+          assert_equal 2, check.run
 
           assert_match /README.md/, stdout.string
           refute_match /goodcheck.yml/, stdout.string
         end
 
         Check.new(config_path: builder.config_path.basename, rules: [], targets: [Pathname("."), Pathname("goodcheck.yml")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
-          assert_equal 0, check.run
+          assert_equal 2, check.run
 
           assert_match /README.md/, stdout.string
           assert_match /goodcheck.yml/, stdout.string
@@ -247,12 +265,12 @@ rules:
 EOF
 
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
-          assert_equal 0, check.run
+          assert_equal 2, check.run
           refute_match /\.file/, stdout.string
         end
 
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("."), Pathname(".file")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
-          assert_equal 0, check.run
+          assert_equal 2, check.run
           assert_match /\.file/, stdout.string
         end
       end

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -106,7 +106,7 @@ EOF
 
       stdout, _, status = shell(goodcheck, "check", ".", chdir: builder.path)
 
-      assert status.success?
+      refute status.success?
       assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout
     end
   end
@@ -136,7 +136,7 @@ EOF
 
       stdout, _, status = shell(goodcheck, "check", "--format=json", ".", chdir: builder.path)
 
-      assert status.success?
+      refute status.success?
       assert_equal [{
                       rule_id: "foo",
                       path: "app/models/user.rb",
@@ -177,7 +177,7 @@ EOF
 
       stdout, _, status = shell(goodcheck, "check", chdir: builder.path)
 
-      assert status.success?
+      refute status.success?
       assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout
     end
   end
@@ -212,7 +212,7 @@ EOF
 
       stdout, _, status = shell(goodcheck, "check", "-R", "bar", chdir: builder.path)
 
-      assert status.success?
+      refute status.success?
       refute_match %r(app/models/user\.rb), stdout
       assert_match %r(app/views/welcome/index\.html\.erb), stdout
     end


### PR DESCRIPTION
As discussed in https://github.com/sider/goodcheck/issues/24, `goodcheck check` now exits with `2` when it finds some matching text.

The error status is `2` and not `1` because `1` is what `ruby` exits from an error.