### PR TITLE
Bump StrongJSON version

### DIFF
--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
 
   spec.add_runtime_dependency "activesupport", "~> 5.0"
-  spec.add_runtime_dependency "strong_json", "~> 0.5.0"
+  spec.add_runtime_dependency "strong_json", "~> 0.7.1"
   spec.add_runtime_dependency "rainbow", "~> 3.0.0"
   spec.add_runtime_dependency "httpclient", "~> 2.8.3"
 end

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Regexp based customizable linter"
   spec.description   = "Regexp based customizable linter"
-  spec.homepage      = "https://github.com/sideci/goodcheck"
+  spec.homepage      = "https://github.com/sider/goodcheck"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Currently, the latest version is 0.7.1, there is no reason to continue to depend on the old version.

In our environment, we can not resolve the following conflict and update the goodcheck.

```
Bundler could not find compatible versions for gem "strong_json":                                                         
  In snapshot (Gemfile.lock):                                                                                             
    strong_json (= 0.5.0)                                                                                                 
                                                                                                                          
  In Gemfile:                                                                                                             
    goodcheck was resolved to 1.4.0, which depends on                                                                     
      strong_json (~> 0.5.0)                                                                                              

    node_harness was resolved to 1.6.6, which depends on     
      strong_json (~> 0.7.1)  

Running `bundle update` will rebuild your snapshot from scratch, using only                                               
the gems in your Gemfile, which may resolve the conflict.    

```