### PR TITLE
Fix error when pattern including End-of-Line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -20,14 +20,14 @@ module Goodcheck
       end
 
       def issue(issue)
-        line = issue.buffer.line(issue.location.start_line).chomp
+        line = issue.buffer.line(issue.location.start_line)
         end_column = if issue.location.start_line == issue.location.end_line
                        issue.location.end_column
                      else
                        line.bytesize
                      end
-        colored_line = line.byteslice(0, issue.location.start_column) + Rainbow(line.byteslice(issue.location.start_column, end_column - issue.location.start_column)).red + line.byteslice(end_column, line.bytesize - end_column)
-        stdout.puts "#{issue.path}:#{issue.location.start_line}:#{colored_line}:\t#{issue.rule.message.lines.first.chomp}"
+        colored_line = line.byteslice(0, issue.location.start_column) + Rainbow(line.byteslice(issue.location.start_column, end_column - issue.location.start_column)).red + line.byteslice(end_column, line.bytesize)
+        stdout.puts "#{issue.path}:#{issue.location.start_line}:#{colored_line.chomp}:\t#{issue.rule.message.lines.first.chomp}"
       end
     end
   end

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -15,7 +15,7 @@ rules:
     pattern:
       - foo
       - bar
-    glob: 
+    glob:
       - "app/models/**/*.rb"
 EOF
 
@@ -160,7 +160,7 @@ rules:
   - id: foo
     message: Foo
     pattern: 猫
-    glob: 
+    glob:
       - pattern: euc-jp
         encoding: EUC-JP
       - pattern: utf-8
@@ -272,6 +272,27 @@ EOF
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("."), Pathname(".file")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
           assert_match /\.file/, stdout.string
+        end
+      end
+    end
+  end
+
+  def test_pattern_end_of_line
+    TestCaseBuilder.tmpdir do |builder|
+      builder.cd do
+        reporter = Reporters::Text.new(stdout: stdout)
+        builder.file name: Pathname("abc.txt"), content: "foo\r\n"
+        builder.config content: <<EOF
+rules:
+  - id: foo
+    message: Foo
+    pattern:
+      regexp: "foo.*"
+EOF
+
+        Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("abc.txt")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
+          assert_equal 2, check.run
+          assert_equal "abc.txt:1:foo:\tFoo\n", stdout.string
         end
       end
     end


### PR DESCRIPTION
This PR fixes `TypeError` raised when checking rules matching End-of-Line (EOL).

For example:

```yaml
# goodcheck.yml
rules:
  - id: foo
    message: Foo
    pattern:
      regexp: "foo.*"
```

Checked file (`foo.txt`):

```
foo\r\n
```

Run `goodcheck check foo.txt` command.

Error:

```
TypeError: no implicit conversion of nil into String
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/reporters/text.rb:29:in `+'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/reporters/text.rb:29:in `issue'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:35:in `block (4 levels) in run'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/analyzer.rb:40:in `each'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/analyzer.rb:40:in `scan'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:33:in `block (3 levels) in run'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/reporters/text.rb:19:in `rule'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:31:in `block (2 levels) in run'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:79:in `block (6 levels) in each_check'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/config.rb:22:in `each'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/config.rb:22:in `rules_for_path'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:66:in `block (5 levels) in each_check'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/reporters/text.rb:15:in `file'
    /Users/koba/git/ybiquitous/goodcheck/lib/goodcheck/commands/check.rb:63:in `block (4 levels) in each_check'
    ...
```

### Problem

I think `chomp` is the problem at `text.rb` line 23. 👇 

https://github.com/sider/goodcheck/blob/34021883d39ee1f68791bc904d5b34e698fc5afd/lib/goodcheck/reporters/text.rb#L23

I show inspected local variables: 👇 

Before:

```ruby
{:line=>"foo",
 :end_column=>4,
 :"line.bytesize"=>3,
 :"line.byteslice(end_column, line.bytesize - end_column)"=>nil}
```

After:

```ruby
{:line=>"foo\r\n",
 :end_column=>4,
 :"line.bytesize"=>5,
 :"line.byteslice(end_column, line.bytesize - end_column)"=>"\n"}
```

Because `chomp` trims `\r\n` from the actual line, as result `line.bytesize - end_column`  is `-1` (= `3 - 4`).