### PR TITLE
Fix position calculation

### DIFF
--- a/lib/goodcheck/buffer.rb
+++ b/lib/goodcheck/buffer.rb
@@ -8,29 +8,29 @@ module Goodcheck
       @content = content
     end
 
-    def line_starts
-      unless @line_starts
-        @line_starts = []
+    def line_ranges
+      unless @line_ranges
+        @line_ranges = []
 
         start_position = 0
 
-        content.lines.each do |line|
-          range = start_position..(start_position + line.bytesize)
-          @line_starts << range
-          start_position = range.end
+        content.split(/\n/, -1).each do |line|
+          range = start_position...(start_position + line.bytesize)
+          @line_ranges << range
+          start_position = range.end + 1
         end
       end
 
-      @line_starts
+      @line_ranges
     end
 
     def location_for_position(position)
-      line_index = line_starts.bsearch_index do |range|
-        position < range.end
+      line_index = line_ranges.bsearch_index do |range|
+        position <= range.end
       end
 
       if line_index
-        [line_index + 1, position - line_starts[line_index].begin]
+        [line_index + 1, position - line_ranges[line_index].begin]
       end
     end
 
@@ -39,9 +39,9 @@ module Goodcheck
     end
 
     def position_for_location(line, column)
-      if (range = line_starts[line-1])
+      if (range = line_ranges[line-1])
         pos = range.begin + column
-        if pos < range.end
+        if pos <= range.end
           pos
         end
       end

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -11,15 +11,21 @@ ipsum
 🐈
   EOF
 
+  def assert_string_range(string, expected, actual)
+    assert_equal expected, actual
+    assert_equal string.byteslice(expected), string.byteslice(actual)
+  end
+
   def test_line_starts
     buffer = Buffer.new(path: Pathname("a.txt"), content: CONTENT)
 
-    assert_equal 0..6, buffer.line_starts[0]
-    assert_equal 6..12, buffer.line_starts[1]
-    assert_equal 12..37, buffer.line_starts[2]
-    assert_equal 37..42, buffer.line_starts[3]
-    assert_equal 42..47, buffer.line_starts[4]
-    assert_nil buffer.line_starts[6]
+    assert_string_range CONTENT, 0...5, buffer.line_ranges[0]
+    assert_string_range CONTENT, 6...11, buffer.line_ranges[1]
+    assert_string_range CONTENT, 12...36, buffer.line_ranges[2]
+    assert_string_range CONTENT, 37...41, buffer.line_ranges[3]
+    assert_string_range CONTENT, 42...46, buffer.line_ranges[4]
+    assert_string_range CONTENT, 47...47, buffer.line_ranges[5]
+    assert_nil buffer.line_ranges[6]
   end
 
   def test_location_for_position
@@ -27,9 +33,13 @@ ipsum
 
     assert_equal [1,0], buffer.location_for_position(0)
     assert_equal [1,1], buffer.location_for_position(1)
+    assert_equal [1,4], buffer.location_for_position(4)
     assert_equal [1,5], buffer.location_for_position(5)
     assert_equal [2,0], buffer.location_for_position(6)
     assert_equal [3,0], buffer.location_for_position(12)
+    assert_equal [4,0], buffer.location_for_position(37)
+    assert_equal [5,0], buffer.location_for_position(42)
+    assert_equal [6,0], buffer.location_for_position(47)
     assert_nil buffer.location_for_position(120)
   end
 
@@ -38,6 +48,7 @@ ipsum
 
     assert_equal 0, buffer.position_for_location(1, 0)
     assert_equal 1, buffer.position_for_location(1, 1)
+    assert_equal 4, buffer.position_for_location(1, 4)
     assert_equal 5, buffer.position_for_location(1, 5)
     assert_equal 6, buffer.position_for_location(2, 0)
     assert_nil buffer.position_for_location(100, 0)

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -15,8 +15,8 @@ class JSONReporterTest < Minitest::Test
       reporter.file Pathname("foo.txt") do
         rule = Rule.new(id: "id", patterns: [], message: "Message", justifications: ["reason1", "reason2"], globs: [], fails: [], passes: [])
         reporter.rule rule do
-          buffer = Buffer.new(path: Pathname("foo.txt"), content: "a b c d e")
-          issue = Issue.new(buffer: buffer, range: 0..2, rule: rule, text: "a ")
+          buffer = Buffer.new(path: Pathname("foo.txt"), content: "a\nb\nc\nd\ne")
+          issue = Issue.new(buffer: buffer, range: 0...2, rule: rule, text: "a ")
           reporter.issue(issue)
         end
       end
@@ -29,8 +29,8 @@ class JSONReporterTest < Minitest::Test
                     location: {
                       start_line: 1,
                       start_column: 0,
-                      end_line: 1,
-                      end_column: 2,
+                      end_line: 2,
+                      end_column: 0,
                     },
                     message: "Message",
                     justifications: ["reason1", "reason2"]


### PR DESCRIPTION
Fix JSON reporter position calculation failure, which didn't handle correctly when the string ends with `\n`. (The line and column containd `nil`.)