### PR TITLE
Add exclude attribute in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Value of `import` can be an array of:
 
 The rules file is a YAML file with array of rules.
 
+## Excluding files
+
+`goodcheck.yml` can have optional `exclude` attribute.
+
+```yaml
+rules: []
+exclude:
+  - node_modules
+  - vendor
+```
+
+Value of `exclude` can be a string or an array of strings representing the glob pattern for excluded files.
+
 ## Commands
 
 ### `goodcheck init [options]`

--- a/lib/goodcheck/commands/init.rb
+++ b/lib/goodcheck/commands/init.rb
@@ -14,6 +14,10 @@ rules:
       - Signup via Github
     pass:
       - Signup via GitHub
+
+exclude:
+  - node_modules
+  - vendor
       EOC
 
       attr_reader :stdout

--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -1,9 +1,11 @@
 module Goodcheck
   class Config
     attr_reader :rules
+    attr_reader :exclude_paths
 
-    def initialize(rules:)
+    def initialize(rules:, exclude_paths:)
       @rules = rules
+      @exclude_paths = exclude_paths
     end
 
     def rules_for_path(path, rules_filter:, &block)

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -34,8 +34,13 @@ module Goodcheck
 
       let :import_target, string
       let :imports, array(import_target)
+      let :exclude, enum(array(string), string)
 
-      let :config, object(rules: rules, import: optional(imports))
+      let :config, object(
+        rules: rules,
+        import: optional(imports),
+        exclude: optional(exclude)
+      )
     end
 
     attr_reader :path
@@ -65,7 +70,9 @@ module Goodcheck
           load_import rules, import
         end
 
-        Config.new(rules: rules)
+        exclude_paths = Array(content[:exclude])
+
+        Config.new(rules: rules, exclude_paths: exclude_paths)
       end
     end
 

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -168,6 +168,34 @@ class ConfigLoaderTest < Minitest::Test
     end
   end
 
+  def test_load_exclude
+    loader = ConfigLoader.new(
+      path: Pathname("hello.yml"),
+      content: {
+        rules: [],
+        exclude: ["**/node_modules"]
+      },
+      stderr: stderr,
+      import_loader: import_loader
+    )
+    config = loader.load
+    assert_equal ["**/node_modules"], config.exclude_paths
+  end
+
+  def test_load_exclude_string
+    loader = ConfigLoader.new(
+      path: Pathname("hello.yml"),
+      content: {
+        rules: [],
+        exclude: "**/node_modules"
+      },
+      stderr: stderr,
+      import_loader: import_loader
+    )
+    config = loader.load
+    assert_equal ["**/node_modules"], config.exclude_paths
+  end
+
   def test_load_config_failure2
     loader = ConfigLoader.new(path: Pathname("hello.yml"), content: "a string", stderr: stderr, import_loader: import_loader)
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -11,12 +11,15 @@ class ConfigTest < Minitest::Test
   def test_rules_for_path
     loader = ConfigLoader.new(path: nil, content: nil, stderr: stderr, import_loader: nil)
 
-    config = Config.new(rules: [
-      loader.load_rule({ id: "rule1", glob: ["**/*.rb"], message: "" }),
-      loader.load_rule({ id: "rule2", glob: ["*.rb", "app/views/**/*.html.erb"], message: "" }),
-      loader.load_rule({ id: "rule3", glob: ["app/**/*.rb"], message: "" }),
-      loader.load_rule({ id: "rule4", glob: ["**/*.ts{,x}"], message: "" })
-    ])
+    config = Config.new(
+      rules: [
+        loader.load_rule({ id: "rule1", glob: ["**/*.rb"], message: "" }),
+        loader.load_rule({ id: "rule2", glob: ["*.rb", "app/views/**/*.html.erb"], message: "" }),
+        loader.load_rule({ id: "rule3", glob: ["app/**/*.rb"], message: "" }),
+        loader.load_rule({ id: "rule4", glob: ["**/*.ts{,x}"], message: "" })
+      ],
+      exclude_paths: []
+    )
 
     assert_equal ["rule1", "rule2"], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
     assert_equal ["rule1", "rule3"], config.rules_for_path(Pathname("app/models/user.rb"), rules_filter: []).map(&:first).map(&:id)
@@ -27,9 +30,12 @@ class ConfigTest < Minitest::Test
   def test_rules_for_path_glob_empty
     loader = ConfigLoader.new(path: nil, content: nil, stderr: stderr, import_loader: nil)
 
-    config = Config.new(rules: [
-      loader.load_rule({ id: "rule1", glob: [], message: "" }),
-    ])
+    config = Config.new(
+      rules: [
+        loader.load_rule({ id: "rule1", glob: [], message: "" }),
+      ],
+      exclude_paths: []
+    )
 
     assert_equal ["rule1"], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
   end
@@ -37,11 +43,14 @@ class ConfigTest < Minitest::Test
   def test_rules_for_filter
     loader = ConfigLoader.new(path: nil, content: nil, stderr: stderr, import_loader: nil)
 
-    config = Config.new(rules: [
-      loader.load_rule({ id: "rule1", glob: [], message: "" }),
-      loader.load_rule({ id: "rule1.x", glob: [], message: "" }),
-      loader.load_rule({ id: "rule2", glob: [], message: "" }),
-    ])
+    config = Config.new(
+      rules: [
+        loader.load_rule({ id: "rule1", glob: [], message: "" }),
+        loader.load_rule({ id: "rule1.x", glob: [], message: "" }),
+        loader.load_rule({ id: "rule2", glob: [], message: "" }),
+      ],
+      exclude_paths: []
+    )
 
     assert_equal ["rule1", "rule1.x"], config.rules_for_path(Pathname("bar.rb"), rules_filter: ["rule1"]).map(&:first).map(&:id)
   end


### PR DESCRIPTION
This PR allows writing `exclude:` attribute in the config file.

```yaml
rules: []

exclude:
  - node_modules
  - vendor
```

The value of `exclude` is a glob pattern. I'm not very sure if glob pattern is the best option for this. (`.gitignore` syntax may be another possible option.)