### PR TITLE
Test there is no content

### DIFF
--- a/lib/goodcheck/analyzer.rb
+++ b/lib/goodcheck/analyzer.rb
@@ -10,23 +10,30 @@ module Goodcheck
 
     def scan(&block)
       if block_given?
-        issues = []
-
         regexp = Regexp.union(*rule.patterns.map(&:regexp))
-        scanner = StringScanner.new(buffer.content)
 
-        while true
-          case
-          when scanner.scan_until(regexp)
-            text = scanner.matched
-            range = (scanner.pos - text.bytesize) .. scanner.pos
-            issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
-          else
-            break
+        unless rule.negated?
+          issues = []
+
+          scanner = StringScanner.new(buffer.content)
+
+          while true
+            case
+            when scanner.scan_until(regexp)
+              text = scanner.matched
+              range = (scanner.pos - text.bytesize) .. scanner.pos
+              issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+            else
+              break
+            end
+          end
+
+          issues.each(&block)
+        else
+          unless regexp =~ buffer.content
+            yield Issue.new(buffer: buffer, range: nil, rule: rule, text: text)
           end
         end
-
-        issues.each(&block)
       else
         enum_for(:scan)
       end

--- a/lib/goodcheck/issue.rb
+++ b/lib/goodcheck/issue.rb
@@ -17,13 +17,15 @@ module Goodcheck
     end
 
     def location
-      unless @location
-        start_line, start_column = buffer.location_for_position(range.begin)
-        end_line, end_column = buffer.location_for_position(range.end)
-        @location = Location.new(start_line: start_line, start_column: start_column, end_line: end_line, end_column: end_column)
-      end
+      if range
+        unless @location
+          start_line, start_column = buffer.location_for_position(range.begin)
+          end_line, end_column = buffer.location_for_position(range.end)
+          @location = Location.new(start_line: start_line, start_column: start_column, end_line: end_line, end_column: end_column)
+        end
 
-      @location
+        @location
+      end
     end
   end
 end

--- a/lib/goodcheck/reporters/json.rb
+++ b/lib/goodcheck/reporters/json.rb
@@ -15,14 +15,15 @@ module Goodcheck
         yield
 
         json = issues.map do |issue|
+          location = issue.location
           {
             rule_id: issue.rule.id,
             path: issue.path,
-            location: {
-              start_line: issue.location.start_line,
-              start_column: issue.location.start_column,
-              end_line: issue.location.end_line,
-              end_column: issue.location.end_column
+            location: location && {
+              start_line: location.start_line,
+              start_column: location.start_column,
+              end_line: location.end_line,
+              end_column: location.end_column
             },
             message: issue.rule.message,
             justifications: issue.rule.justifications

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -20,14 +20,18 @@ module Goodcheck
       end
 
       def issue(issue)
-        line = issue.buffer.line(issue.location.start_line)
-        end_column = if issue.location.start_line == issue.location.end_line
-                       issue.location.end_column
-                     else
-                       line.bytesize
-                     end
-        colored_line = line.byteslice(0, issue.location.start_column) + Rainbow(line.byteslice(issue.location.start_column, end_column - issue.location.start_column)).red + line.byteslice(end_column, line.bytesize)
-        stdout.puts "#{issue.path}:#{issue.location.start_line}:#{colored_line.chomp}:\t#{issue.rule.message.lines.first.chomp}"
+        if issue.location
+          line = issue.buffer.line(issue.location.start_line)
+          end_column = if issue.location.start_line == issue.location.end_line
+                         issue.location.end_column
+                       else
+                         line.bytesize
+                       end
+          colored_line = line.byteslice(0, issue.location.start_column) + Rainbow(line.byteslice(issue.location.start_column, end_column - issue.location.start_column)).red + line.byteslice(end_column, line.bytesize)
+          stdout.puts "#{issue.path}:#{issue.location.start_line}:#{colored_line.chomp}:\t#{issue.rule.message.lines.first.chomp}"
+        else
+          stdout.puts "#{issue.path}:-:#{issue.buffer.line(1).chomp}:\t#{issue.rule.message.lines.first.chomp}"
+        end
       end
     end
   end

--- a/lib/goodcheck/rule.rb
+++ b/lib/goodcheck/rule.rb
@@ -8,7 +8,7 @@ module Goodcheck
     attr_reader :passes
     attr_reader :fails
 
-    def initialize(id:, patterns:, message:, justifications:, globs:, fails:, passes:)
+    def initialize(id:, patterns:, message:, justifications:, globs:, fails:, passes:, negated:)
       @id = id
       @patterns = patterns
       @message = message
@@ -16,6 +16,11 @@ module Goodcheck
       @globs = globs
       @passes = passes
       @fails = fails
+      @negated = negated
+    end
+
+    def negated?
+      @negated
     end
   end
 end

--- a/sample.yml
+++ b/sample.yml
@@ -10,6 +10,7 @@ rules:
       Maybe, you are misspelling.
     pass: GitHub
     fail: Github
+
   - id: sample.debug_print
     pattern:
       - token: pp
@@ -21,6 +22,36 @@ rules:
       - render "app/views/welcome.html.erb"
     fail:
       - pp("Hello World")
+
+  - id: sample.html
+    not:
+      pattern:
+        - token: <meta charset="utf-8"
+        - token: <meta charset="UTF-8"
+    message: |
+      Use UTF-8 (no BOM).
+    glob: "**/*.html"
+    pass:
+      - |
+        <html>
+          <meta charset="utf-8"/>
+        </html>
+      - |
+        <html>
+          <meta charset="utf-8"></meta>
+        </html>
+      - |
+        <html>
+          <meta charset="UTF-8"></meta>
+        </html>
+    fail:
+      - |
+        <html>
+          <meta charset="iso-8859-1">
+        </html>
+      - |
+        <html>
+        </html>
 
 import:
   - https://gist.githubusercontent.com/soutaro/6362c89acd7d6771ae6ebfc615be402d/raw/7f04b973c2c8df70783cd7deb955ab95d1375b2d/sample.yml

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -25,7 +25,7 @@ NSArray *a = [ NSMutableArray
   end
 
   def new_rule(id, *patterns)
-    Rule.new(id: id, patterns: patterns, message: "hello", justifications: [], globs: [], passes: [], fails: [])
+    Rule.new(id: id, patterns: patterns, message: "hello", justifications: [], globs: [], passes: [], fails: [], negated: false)
   end
 
   def test_analyzer

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -168,7 +168,7 @@ EOF
 
         assert_equal 1, check.run
 
-        assert_match /Invalid config at \[rules\]\[0\]\[pattern\]/, stderr.string
+        assert_match /Invalid config at \[rules\]\[0\]/, stderr.string
       end
     end
   end

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -168,8 +168,8 @@ class ConfigLoaderTest < Minitest::Test
       {
         id: "com.id.1",
         message: "Some message",
-        pattern: {
-          not: "foo.bar"
+        not: {
+          pattern: "foo.bar"
         }
       }
     )
@@ -243,13 +243,9 @@ class ConfigLoaderTest < Minitest::Test
                               stderr: stderr,
                               import_loader: import_loader)
 
-    exn = nil
-    begin
+    assert_raises StrongJSON::Type::Error do
       loader.load
-    rescue => exn
     end
-
-    assert_equal [:rules, 0, :glob], exn.path
   end
 
   def test_load_config

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -108,6 +108,7 @@ class ConfigLoaderTest < Minitest::Test
     assert_equal [], rule.globs
     assert_equal [], rule.passes
     assert_equal [], rule.fails
+    refute_operator rule, :negated?
   end
 
   def test_load_rule_case
@@ -159,6 +160,29 @@ class ConfigLoaderTest < Minitest::Test
 
     assert_match /`case_insensitive` option is deprecated/, stderr.string
     assert_equal 1, stderr.string.scan(/`case_insensitive` option is deprecated/).count
+  end
+
+  def test_load_rule_negated
+    loader = config_loader()
+    rule = loader.load_rule(
+      {
+        id: "com.id.1",
+        message: "Some message",
+        pattern: {
+          not: "foo.bar"
+        }
+      }
+    )
+
+    assert_instance_of Rule, rule
+    assert_equal "com.id.1", rule.id
+    assert_equal "Some message", rule.message
+    assert_equal ["foo.bar"], rule.patterns.map(&:source)
+    assert_equal [], rule.justifications
+    assert_equal [], rule.globs
+    assert_equal [], rule.passes
+    assert_equal [], rule.fails
+    assert_operator rule, :negated?
   end
 
   def test_load_config_failure

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -13,7 +13,7 @@ class JSONReporterTest < Minitest::Test
 
     json_analysis = reporter.analysis do
       reporter.file Pathname("foo.txt") do
-        rule = Rule.new(id: "id", patterns: [], message: "Message", justifications: ["reason1", "reason2"], globs: [], fails: [], passes: [])
+        rule = Rule.new(id: "id", patterns: [], message: "Message", justifications: ["reason1", "reason2"], globs: [], fails: [], passes: [], negated: false)
         reporter.rule rule do
           buffer = Buffer.new(path: Pathname("foo.txt"), content: "a\nb\nc\nd\ne")
           issue = Issue.new(buffer: buffer, range: 0...2, rule: rule, text: "a ")


### PR DESCRIPTION
Now we can write a *negated* rule to check the absence of patterns in a file.

```yaml
rules:
  - id: foo
    not:
      pattern: frozen_string_literal: true
    message: |
      Specify frozen_string_literal magic comment.
    glob:
      - "**/*.rb"
```