### PR TITLE
Add rule without pattern

### DIFF
--- a/lib/goodcheck/analyzer.rb
+++ b/lib/goodcheck/analyzer.rb
@@ -31,28 +31,32 @@ module Goodcheck
 
     def scan(&block)
       if block_given?
-        regexp = Regexp.union(*patterns.map(&:regexp))
-
-        unless rule.negated?
-          issues = []
-
-          scanner = StringScanner.new(buffer.content)
-
-          while true
-            case
-            when scanner.scan_until(regexp)
-              text = scanner.matched
-              range = (scanner.pos - text.bytesize) .. scanner.pos
-              issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
-            else
-              break
-            end
-          end
-
-          issues.each(&block)
+        if rule.patterns.empty?
+          yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
         else
-          unless regexp =~ buffer.content
-            yield Issue.new(buffer: buffer, range: nil, rule: rule, text: text)
+          regexp = Regexp.union(*patterns.map(&:regexp))
+
+          unless rule.negated?
+            issues = []
+
+            scanner = StringScanner.new(buffer.content)
+
+            while true
+              case
+              when scanner.scan_until(regexp)
+                text = scanner.matched
+                range = (scanner.pos - text.bytesize) .. scanner.pos
+                issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+              else
+                break
+              end
+            end
+
+            issues.each(&block)
+          else
+            unless regexp =~ buffer.content
+              yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
+            end
           end
         end
       else

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -105,6 +105,9 @@ puts "font-size"
   font-size: 123px;
 }
       EOF
+      builder.file name: Pathname("user.html"), content: <<-EOF
+<h1 style="font-size: 12px">hello world<h1>
+      EOF
 
       builder.cd do
         reporter = Reporters::Text.new(stdout: stdout)
@@ -112,9 +115,10 @@ puts "font-size"
 
         assert_equal 2, check.run
 
-        # Matches pattern glob
-        assert_includes stdout.string.lines, "user.css:1:.hello {:\tFoo\n"
-        assert_includes stdout.string.lines, "user.rb:2:puts \"font-size\":\tFoo\n"
+        assert_equal <<-MSG, stdout.string
+user.css:1:.hello {:\tFoo
+user.rb:2:puts "font-size":\tFoo
+        MSG
       end
     end
   end

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -372,4 +372,32 @@ EOF
       end
     end
   end
+
+  def test_no_pattern_rule
+    mktmpdir do |path|
+      config_path = path + "goodcheck.yml"
+
+      loader = ConfigLoader.new(
+        path: config_path,
+        content: {
+          rules: [
+            {
+              id: "1",
+              message: "foo",
+              glob: "db/schema.rb"
+            },
+          ],
+        },
+        stderr: stderr,
+        import_loader: import_loader
+      )
+
+      config = loader.load
+
+      config.rules.find {|rule| rule.id == "1" }.tap do |rule|
+        assert_equal ["db/schema.rb"], rule.globs.map(&:pattern)
+        assert_equal [], rule.patterns
+      end
+    end
+  end
 end


### PR DESCRIPTION
We can now define a rule without `pattern`.

This rule matches any file specified in `glob` (`glob` is required in this case.) This rule is useful to detect if a file is changed or not, would be useful for reviewing `Gemfile.lock`, `package-lock.json`, `db/schema.rb`, ...

```yaml
rules:
  - id: migration
    message: |
      See the operation manual for migration: https://example.com/docs/1
    glob: "db/schema.rb"
```