### PR TITLE
Add variable syntax in token pattern

### DIFF
--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", "~> 1.3.6"
 
   spec.add_runtime_dependency "activesupport", ">= 4.0", "< 6.0"
-  spec.add_runtime_dependency "strong_json", "~> 1.0.1"
+  spec.add_runtime_dependency "strong_json", "~> 1.1.0"
   spec.add_runtime_dependency "rainbow", "~> 3.0.0"
   spec.add_runtime_dependency "httpclient", "~> 2.8.3"
 end

--- a/lib/goodcheck/analyzer.rb
+++ b/lib/goodcheck/analyzer.rb
@@ -15,33 +15,79 @@ module Goodcheck
         if trigger.patterns.empty?
           yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
         else
-          regexp = Regexp.union(*trigger.patterns.map(&:regexp))
+          var_pats, novar_pats = trigger.patterns.partition {|pat|
+            pat.is_a?(Pattern::Token) && !pat.variables.empty?
+          }
 
-          unless trigger.negated?
-            issues = []
-
-            scanner = StringScanner.new(buffer.content)
-
-            while true
-              case
-              when scanner.scan_until(regexp)
-                text = scanner.matched
-                range = (scanner.pos - text.bytesize) .. scanner.pos
-                issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
-              else
-                break
-              end
+          unless var_pats.empty?
+            var_pats.each do |pat|
+              scan_var pat, &block
             end
+          end
 
-            issues.each(&block)
-          else
-            unless regexp =~ buffer.content
-              yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
-            end
+          unless novar_pats.empty?
+            regexp = Regexp.union(*novar_pats.map(&:regexp))
+            scan_simple regexp, &block
           end
         end
       else
         enum_for(:scan)
+      end
+    end
+
+    def scan_simple(regexp, &block)
+      unless trigger.negated?
+        issues = []
+
+        scanner = StringScanner.new(buffer.content)
+
+        while true
+          case
+          when scanner.scan_until(regexp)
+            text = scanner.matched
+            range = (scanner.pos - text.bytesize) .. scanner.pos
+            issues << Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+          else
+            break
+          end
+        end
+
+        issues.each(&block)
+      else
+        unless regexp =~ buffer.content
+          yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
+        end
+      end
+    end
+
+    def scan_var(pat)
+      scanner = StringScanner.new(buffer.content)
+
+      unless trigger.negated?
+        while true
+          case
+          when scanner.scan_until(pat.regexp)
+            if pat.test_variables(scanner)
+              text = scanner.matched
+              range = (scanner.pos - text.bytesize) .. scanner.pos
+              yield Issue.new(buffer: buffer, range: range, rule: rule, text: text)
+            end
+          else
+            break
+          end
+        end
+      else
+        while true
+          case
+          when scanner.scan_until(pat.regexp)
+            if pat.test(scanner)
+              break
+            end
+          else
+            yield Issue.new(buffer: buffer, range: nil, rule: rule, text: nil)
+            break
+          end
+        end
       end
     end
   end

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -35,9 +35,36 @@ module Goodcheck
                           })
       let :glob, array_or(one_glob)
 
+      let :var_pattern, any
+      let :variable_pattern, array_or(var_pattern)
+      let :negated_variable_pattern, object(not: variable_pattern)
+
+      let :where, hash(
+        enum(
+          variable_pattern,
+          negated_variable_pattern,
+          literal(true),
+          detector: -> (value) {
+            case
+            when value.is_a?(Hash) && value.key?(:not)
+              negated_variable_pattern
+            when value == true
+              literal(true)
+            else
+              variable_pattern
+            end
+          }
+        )
+      )
+
       let :regexp_pattern, object(regexp: string, case_sensitive: boolean?, multiline: boolean?, glob: optional(glob))
       let :literal_pattern, object(literal: string, case_sensitive: boolean?, glob: optional(glob))
-      let :token_pattern, object(token: string, case_sensitive: boolean?, glob: optional(glob))
+      let :token_pattern, object(
+        token: string,
+        case_sensitive: boolean?,
+        glob: optional(glob),
+        where: optional(where)
+      )
 
       let :pattern, enum(regexp_pattern,
                          literal_pattern,
@@ -346,9 +373,51 @@ module Goodcheck
         when pattern[:token]
           tok = pattern[:token]
           cs = case_sensitive?(pattern)
-          Pattern::Token.new(source: tok, case_sensitive: cs)
+          Pattern::Token.new(source: tok, variables: load_token_vars(pattern[:where]), case_sensitive: cs)
         end
       end
+    end
+
+    def load_token_vars(pattern)
+      case pattern
+      when Hash
+        pattern.each.with_object({}) do |(key, value), hash|
+          hash[key.to_sym] = load_var_pattern(value)
+        end
+      else
+        {}
+      end
+    end
+
+    def load_var_pattern(pattern)
+      if pattern.is_a?(Hash) && pattern[:not]
+        negated = true
+        pattern = pattern[:not]
+      else
+        negated = false
+      end
+
+      pattern = [] if pattern == true
+
+      patterns = array(pattern).map do |pat|
+        case pat
+        when String
+          if pat =~ /\A\/(.*)\/([im]*)\Z/
+            source = $1
+            opts = $2
+            options = 0
+            options |= ::Regexp::IGNORECASE if opts =~ /i/
+            options |= ::Regexp::MULTILINE if opts =~ /m/
+            ::Regexp.new(source, options)
+          else
+            pat
+          end
+        else
+          pat
+        end
+      end
+
+      Pattern::Token::VarPattern.new(patterns: patterns, negated: negated)
     end
 
     def case_sensitive?(pattern)

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -327,7 +327,7 @@ module Goodcheck
     def load_pattern(pattern)
       case pattern
       when String
-        Pattern.literal(pattern, case_sensitive: true)
+        Pattern::Literal.new(source: pattern, case_sensitive: true)
       when Hash
         if pattern[:glob]
           print_warning_once "🌏 Pattern with glob is deprecated: globs are ignored at all."
@@ -337,16 +337,16 @@ module Goodcheck
         when pattern[:literal]
           cs = case_sensitive?(pattern)
           literal = pattern[:literal]
-          Pattern.literal(literal, case_sensitive: cs)
+          Pattern::Literal.new(source: literal, case_sensitive: cs)
         when pattern[:regexp]
           regexp = pattern[:regexp]
           cs = case_sensitive?(pattern)
           multiline = pattern[:multiline]
-          Pattern.regexp(regexp, case_sensitive: cs, multiline: multiline)
+          Pattern::Regexp.new(source: regexp, case_sensitive: cs, multiline: multiline)
         when pattern[:token]
           tok = pattern[:token]
           cs = case_sensitive?(pattern)
-          Pattern.token(tok, case_sensitive: cs)
+          Pattern::Token.new(source: tok, case_sensitive: cs)
         end
       end
     end

--- a/lib/goodcheck/pattern.rb
+++ b/lib/goodcheck/pattern.rb
@@ -36,41 +36,171 @@ module Goodcheck
     end
 
     class Token
-      attr_reader :source, :case_sensitive
+      attr_reader :source, :case_sensitive, :variables
 
-      def initialize(source:, case_sensitive:)
-        @case_sensitive = case_sensitive
+      def initialize(source:, variables:, case_sensitive:)
         @source = source
+        @variables = variables
+        @case_sensitive = case_sensitive
       end
 
       def regexp
-        @regexp ||= Token.compile_tokens(source, case_sensitive: case_sensitive)
+        @regexp ||= Token.compile_tokens(source, variables, case_sensitive: case_sensitive)
       end
 
-      def self.compile_tokens(source, case_sensitive:)
+      class VarPattern
+        attr_reader :negated
+        attr_reader :patterns
+        attr_accessor :type
+
+        def initialize(patterns:, negated:)
+          @patterns = patterns
+          @negated = negated
+        end
+
+        def cast(str)
+          case type
+          when :int
+            str.to_i
+          when :float, :number
+            str.to_f
+          else
+            str
+          end
+        end
+
+        def test(str)
+          return true if patterns.empty?
+
+          value = cast(str)
+
+          unless negated
+            patterns.any? {|pattern| pattern === value }
+          else
+            patterns.none? {|pattern| pattern === value }
+          end
+        end
+
+        def self.empty
+          VarPattern.new(patterns: [], negated: false)
+        end
+      end
+
+      def test_variables(match)
+        variables.all? do |name, var|
+          str = match[name]
+          str && var.test(str)
+        end
+      end
+
+      @@TYPES = {}
+
+      @@TYPES[:string] = -> (name) {
+        ::Regexp.union(
+          /"(?<#{name}>(?:[^"]|\")*)"/,
+          /'(?<#{name}>(?:[^']|\')*)'/
+        )
+      }
+
+      @@TYPES[:number] = -> (name) {
+        ::Regexp.union(
+          regexp_for_type(name: name, type: :int),
+          regexp_for_type(name: name, type: :float)
+        )
+      }
+
+      @@TYPES[:int] = -> (name) {
+        ::Regexp.union(
+          /(?<#{name}>[+-]?[1-9](:?\d|_\d)*)/,
+          /(?<#{name}>[+-]?0[dD][0-7]+)/,
+          /(?<#{name}>[+-]?0[oO]?[0-7]+)/,
+          /(?<#{name}>[+-]?0[xX][0-9a-fA-F]+)/,
+          /(?<#{name}>[+-]?0[bB][01]+)/
+        )
+      }
+
+      @@TYPES[:float] = -> (name) {
+        ::Regexp.union(
+          /(?<#{name}>[+-]?\d+\.\d*(:?e[+-]?\d+)?)/,
+          /(?<#{name}>[+-]?\d+(:?e[+-]?\d+)?)/
+        )
+      }
+
+      @@TYPES[:word] = -> (name) {
+        /(?<#{name}>\S+)/
+      }
+
+      @@TYPES[:identifier] = -> (name) {
+        /(?<#{name}>[a-zA-Z_]\w*)\b/
+      }
+
+      # From rails_autolink gem
+      # https://github.com/tenderlove/rails_autolink/blob/master/lib/rails_autolink/helpers.rb#L73
+      # With ')' support, which should be frequently used for markdown or CSS `url(...)`
+      AUTO_LINK_RE = %r{
+        (?: ((?:ed2k|ftp|http|https|irc|mailto|news|gopher|nntp|telnet|webcal|xmpp|callto|feed|svn|urn|aim|rsync|tag|ssh|sftp|rtsp|afs|file):)// | www\. )
+        [^\s<\u00A0")]+
+      }ix
+
+      # https://github.com/tenderlove/rails_autolink/blob/master/lib/rails_autolink/helpers.rb#L81-L82
+      AUTO_EMAIL_LOCAL_RE = /[\w.!#\$%&'*\/=?^`{|}~+-]/
+      AUTO_EMAIL_RE = /(?<!#{AUTO_EMAIL_LOCAL_RE})[\w.!#\$%+-]\.?#{AUTO_EMAIL_LOCAL_RE}*@[\w-]+(?:\.[\w-]+)+/
+
+      @@TYPES[:url] = -> (name) {
+        /\b(?<#{name}>#{AUTO_LINK_RE})/
+      }
+
+      @@TYPES[:email] = -> (name) {
+        /\b(?<#{name}>#{AUTO_EMAIL_RE})/
+      }
+
+      def self.regexp_for_type(name:, type:)
+        ty = type || :word
+        if @@TYPES.key?(ty)
+          @@TYPES[ty][name]
+        end
+      end
+
+      def self.compile_tokens(source, variables, case_sensitive:)
         tokens = []
         s = StringScanner.new(source)
 
         until s.eos?
           case
+          when s.scan(/\${(?<name>[a-zA-Z_]\w*)(?::(?<type>#{::Regexp.union(*@@TYPES.keys.map(&:to_s))}))?}/)
+            name = s[:name].to_sym
+            type = s[:type] && s[:type].to_sym
+
+            if variables.key?(name)
+              variables[name].type = type
+              regexp = regexp_for_type(name: name, type: type).to_s
+              if tokens.empty? && (type == :word || type == :identifier)
+                regexp = /\b#{regexp.to_s}/
+              end
+              tokens << regexp.to_s
+            else
+              tokens << ::Regexp.escape("${")
+              tokens << ::Regexp.escape(name.to_s)
+              tokens << ::Regexp.escape("}")
+            end
           when s.scan(/\(|\)|\{|\}|\[|\]|\<|\>/)
             tokens << ::Regexp.escape(s.matched)
           when s.scan(/\s+/)
             tokens << '\s+'
-          when s.scan(/\w+|[\p{Letter}&&\p{^ASCII}]+/)
+          when s.scan(/\w+|[\p{L}&&\p{^ASCII}]+/)
             tokens << ::Regexp.escape(s.matched)
-          when s.scan(%r{[!"#$%&'=\-^~¥\\|`@*:+;/?.,]+})
+          when s.scan(%r{[!"#%&'=\-^~¥\\|`@*:+;/?.,]+})
             tokens << ::Regexp.escape(s.matched.rstrip)
           when s.scan(/./)
             tokens << ::Regexp.escape(s.matched)
           end
         end
 
-        if tokens.first =~ /\A\p{Letter}/
+        if tokens.first =~ /\A\p{L}/
           tokens.first.prepend('\b')
         end
 
-        if tokens.last =~ /\p{Letter}\Z/
+        if tokens.last =~ /\p{L}\Z/
           tokens.last << '\b'
         end
 

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -38,7 +38,7 @@ NSArray *a = [ NSMutableArray
       buffer: buffer,
       rule: new_rule(id: "rule1"),
       trigger: new_trigger {|trigger|
-        trigger.patterns << Pattern.literal("ipsum", case_sensitive: true)
+        trigger.patterns << Pattern::Literal.new(source: "ipsum", case_sensitive: true)
       }
     )
 
@@ -54,7 +54,7 @@ NSArray *a = [ NSMutableArray
       buffer: buffer,
       rule: new_rule(id: "rule1"),
       trigger: new_trigger {|trigger|
-        trigger.patterns << Pattern.literal("吾輩", case_sensitive: true)
+        trigger.patterns << Pattern::Literal.new(source: "吾輩", case_sensitive: true)
       }
     )
 
@@ -70,7 +70,7 @@ NSArray *a = [ NSMutableArray
       buffer: buffer,
       rule: new_rule(id: "rule1"),
       trigger: new_trigger {|trigger|
-        trigger.patterns << Pattern.token("[NSMutableArray new]", case_sensitive: true)
+        trigger.patterns << Pattern::Token.new(source: "[NSMutableArray new]", case_sensitive: true)
       }
     )
 
@@ -87,8 +87,8 @@ NSArray *a = [ NSMutableArray
       buffer: buffer,
       rule: new_rule(id: "rule1"),
       trigger: new_trigger {|trigger|
-        trigger.patterns << Pattern.regexp("N.Array", case_sensitive: false, multiline: false)
-        trigger.patterns << Pattern.regexp("NSAr.ay", case_sensitive: false, multiline: false)
+        trigger.patterns << Pattern::Regexp.new(source: "N.Array", case_sensitive: false, multiline: false)
+        trigger.patterns << Pattern::Regexp.new(source: "NSAr.ay", case_sensitive: false, multiline: false)
       }
     )
 
@@ -104,7 +104,7 @@ NSArray *a = [ NSMutableArray
       buffer: buffer,
       rule: new_rule(id: "rule1"),
       trigger: new_trigger {|trigger|
-        trigger.patterns << Pattern.token("Array", case_sensitive: true)
+        trigger.patterns << Pattern::Token.new(source: "Array", case_sensitive: true)
       }
     )
 
@@ -122,7 +122,7 @@ atest
         buffer: buffer,
         rule: new_rule(id: "rule1"),
         trigger: new_trigger {|trigger|
-          trigger.patterns << Pattern.regexp('(\btest\b|foo)', case_sensitive: false, multiline: false)
+          trigger.patterns << Pattern::Regexp.new(source: '(\btest\b|foo)', case_sensitive: false, multiline: false)
         }
       )
 

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -1,8 +1,12 @@
 require_relative "test_helper"
 
 class PatternTest < Minitest::Test
+  Token = Goodcheck::Pattern::Token
+  Literal = Goodcheck::Pattern::Literal
+  Regexp = Goodcheck::Pattern::Regexp
+
   def test_tokenize
-    regexp = Goodcheck::Pattern::Token.compile_tokens("[NSData alloc]", case_sensitive: true)
+    regexp = Token.compile_tokens("[NSData alloc]", {}, case_sensitive: true)
     assert_match regexp, "[NSData alloc]"
     assert_match regexp, "NSData *data = [[NSData alloc] init]"
     assert_match regexp, "NSData *data = [[NSData \nalloc] init]"
@@ -11,27 +15,27 @@ class PatternTest < Minitest::Test
   end
 
   def test_tokenize2
-    regexp = Goodcheck::Pattern::Token.compile_tokens("ASCII-8BIT", case_sensitive: true)
+    regexp = Token.compile_tokens("ASCII-8BIT", {}, case_sensitive: true)
     assert_match regexp, "encode('ASCII-8BIT')"
     refute_match regexp, "FASCII-8BITS"
   end
 
   def test_tokenize3
-    regexp = Goodcheck::Pattern::Token.compile_tokens("<br/>", case_sensitive: true)
+    regexp = Token.compile_tokens("<br/>", {}, case_sensitive: true)
     assert_match regexp, "Hello World<br />"
     assert_match regexp, "Hello World <br/ >"
     refute_match regexp, "Hello World <br >"
   end
 
   def test_tokenize4
-    regexp = Goodcheck::Pattern::Token.compile_tokens("沖縄Ruby会議", case_sensitive: true)
+    regexp = Token.compile_tokens("沖縄Ruby会議", {}, case_sensitive: true)
     assert_match regexp, "沖縄Ruby会議"
     assert_match regexp, "沖縄 Ruby 会議"
     refute_match regexp, "沖 縄Ruby会議"
   end
 
   def test_tokenize5
-    regexp = Goodcheck::Pattern::Token.compile_tokens("each", case_sensitive: true)
+    regexp = Token.compile_tokens("each", {}, case_sensitive: true)
     assert_match regexp, "each()"
     assert_match regexp, "foo.each()"
     refute_match regexp, "foreach"
@@ -39,28 +43,175 @@ class PatternTest < Minitest::Test
   end
 
   def test_tokenize6
-    regexp = Goodcheck::Pattern::Token.compile_tokens("each", case_sensitive: false)
+    regexp = Token.compile_tokens("each", {}, case_sensitive: false)
     assert_match regexp, "EACH()"
     assert_match regexp, "foo.Each()"
     refute_match regexp, "FOReaCH"
     refute_match regexp, "test_each_icon"
   end
 
+  def test_tokenize_variable_string
+    regexp = Token.compile_tokens("${color:string}",
+                                  { color: Token::VarPattern.empty },
+                                  case_sensitive: true)
+
+    regexp.match('"hello \\" \\\' world"').tap do |match|
+      assert match
+      assert_equal "hello \\\" \\' world", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_int
+    regexp = Token.compile_tokens("${color:int}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('123').tap do |match|
+      assert match
+      assert_equal "123", match[:color]
+    end
+
+    regexp.match('1_2_3').tap do |match|
+      assert match
+      assert_equal "1_2_3", match[:color]
+    end
+
+    regexp.match('hello world').tap do |match|
+      refute match
+    end
+  end
+
+  def test_tokenize_variable_float
+    regexp = Token.compile_tokens("${color:float}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('1.23').tap do |match|
+      assert match
+      assert_equal "1.23", match[:color]
+    end
+
+    regexp.match('-1.23').tap do |match|
+      assert match
+      assert_equal "-1.23", match[:color]
+    end
+
+    regexp.match('1e+123').tap do |match|
+      assert match
+      assert_equal "1e+123", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_word
+    regexp = Token.compile_tokens("${color:word}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('白色').tap do |match|
+      assert match
+      assert_equal "白色", match[:color]
+    end
+
+    regexp.match('black&white').tap do |match|
+      assert match
+      assert_equal "black&white", match[:color]
+    end
+
+    regexp.match('dark yellow').tap do |match|
+      assert match
+      assert_equal "dark", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_word2
+    Token.compile_tokens("foo ${color:word}", { color: Token::VarPattern.empty }, case_sensitive: true).tap do |regexp|
+      assert_equal /\bfoo\s+(?-mix:(?<color>\S+))/m, regexp
+    end
+
+    Token.compile_tokens("${color:word} foo", { color: Token::VarPattern.empty }, case_sensitive: true).tap do |regexp|
+      assert_equal /(?-mix:\b(?-mix:(?<color>\S+)))\s+foo\b/m, regexp
+    end
+  end
+
+  def test_tokenize_variable_identifier
+    regexp = Token.compile_tokens("${color:identifier}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('soutaro').tap do |match|
+      assert match
+      assert_equal "soutaro", match[:color]
+    end
+
+    regexp.match('p_ck_').tap do |match|
+      assert match
+      assert_equal "p_ck_", match[:color]
+    end
+
+    regexp.match('__gfx__').tap do |match|
+      assert match
+      assert_equal "__gfx__", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_url
+    regexp = Token.compile_tokens("${color:url}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('[rails_autolink](https://github.com/tenderlove/rails_autolink)').tap do |match|
+      assert match
+      assert_equal "https://github.com/tenderlove/rails_autolink", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_email
+    regexp = Token.compile_tokens("${color:email}", { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    regexp.match('Soutaro <matsumoto@soutaro.com>').tap do |match|
+      assert match
+      assert_equal "matsumoto@soutaro.com", match[:color]
+    end
+  end
+
+  def test_tokenize_variable_no_variable
+    regexp = Token.compile_tokens("${color}", { }, case_sensitive: true)
+
+    assert_match regexp, "${ color }"
+  end
+
   def test_literal
-    pattern = Goodcheck::Pattern::Literal.new(source: "hello.world", case_sensitive: false)
+    pattern = Literal.new(source: "hello.world", case_sensitive: false)
     assert_equal "hello.world", pattern.source
     assert_equal /hello\.world/i, pattern.regexp
   end
 
   def test_regexp
-    pattern = Goodcheck::Pattern::Regexp.new(source: "hello.world", case_sensitive: false, multiline: true)
+    pattern = Regexp.new(source: "hello.world", case_sensitive: false, multiline: true)
     assert_equal "hello.world", pattern.source
     assert_equal /hello.world/im, pattern.regexp
   end
 
   def test_tokens
-    pattern = Goodcheck::Pattern::Token.new(source: "hello.world", case_sensitive: true)
+    pattern = Token.new(source: "hello.world", variables: {}, case_sensitive: true)
     assert_equal "hello.world", pattern.source
     assert_equal /\bhello\s*\.\s*world\b/m, pattern.regexp
+  end
+
+  def test_tokens_var
+    pattern = Token.new(source: "bgcolor=${color:string}", variables: { color: Token::VarPattern.empty }, case_sensitive: true)
+
+    assert_match pattern.regexp, "bgcolor='white'"
+    assert_match pattern.regexp, 'bgcolor="pink"'
+    refute_match pattern.regexp, 'bgcolor={gray}'
+  end
+
+  def test_var_pattern
+    Token::VarPattern.new(patterns: [], negated: false).tap do |pat|
+      assert pat.test("any string is okay")
+    end
+
+    Token::VarPattern.new(patterns: ["hello", "world"], negated: false).tap do |pat|
+      pat.type = :string
+      assert pat.test("hello")
+      assert pat.test("world")
+      refute pat.test("lorem")
+    end
+
+    Token::VarPattern.new(patterns: [455], negated: false).tap do |pat|
+      pat.type = :number
+      assert pat.test("455")
+      refute pat.test("123")
+    end
   end
 end

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 
 class PatternTest < Minitest::Test
   def test_tokenize
-    regexp = Goodcheck::Pattern.compile_tokens("[NSData alloc]", case_sensitive: true)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("[NSData alloc]", case_sensitive: true)
     assert_match regexp, "[NSData alloc]"
     assert_match regexp, "NSData *data = [[NSData alloc] init]"
     assert_match regexp, "NSData *data = [[NSData \nalloc] init]"
@@ -11,27 +11,27 @@ class PatternTest < Minitest::Test
   end
 
   def test_tokenize2
-    regexp = Goodcheck::Pattern.compile_tokens("ASCII-8BIT", case_sensitive: true)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("ASCII-8BIT", case_sensitive: true)
     assert_match regexp, "encode('ASCII-8BIT')"
     refute_match regexp, "FASCII-8BITS"
   end
 
   def test_tokenize3
-    regexp = Goodcheck::Pattern.compile_tokens("<br/>", case_sensitive: true)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("<br/>", case_sensitive: true)
     assert_match regexp, "Hello World<br />"
     assert_match regexp, "Hello World <br/ >"
     refute_match regexp, "Hello World <br >"
   end
 
   def test_tokenize4
-    regexp = Goodcheck::Pattern.compile_tokens("沖縄Ruby会議", case_sensitive: true)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("沖縄Ruby会議", case_sensitive: true)
     assert_match regexp, "沖縄Ruby会議"
     assert_match regexp, "沖縄 Ruby 会議"
     refute_match regexp, "沖 縄Ruby会議"
   end
 
   def test_tokenize5
-    regexp = Goodcheck::Pattern.compile_tokens("each", case_sensitive: true)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("each", case_sensitive: true)
     assert_match regexp, "each()"
     assert_match regexp, "foo.each()"
     refute_match regexp, "foreach"
@@ -39,7 +39,7 @@ class PatternTest < Minitest::Test
   end
 
   def test_tokenize6
-    regexp = Goodcheck::Pattern.compile_tokens("each", case_sensitive: false)
+    regexp = Goodcheck::Pattern::Token.compile_tokens("each", case_sensitive: false)
     assert_match regexp, "EACH()"
     assert_match regexp, "foo.Each()"
     refute_match regexp, "FOReaCH"
@@ -47,20 +47,20 @@ class PatternTest < Minitest::Test
   end
 
   def test_literal
-    pattern = Goodcheck::Pattern.literal("hello.world", case_sensitive: false)
-    assert_equal /hello\.world/i, pattern.regexp
+    pattern = Goodcheck::Pattern::Literal.new(source: "hello.world", case_sensitive: false)
     assert_equal "hello.world", pattern.source
+    assert_equal /hello\.world/i, pattern.regexp
   end
 
   def test_regexp
-    pattern = Goodcheck::Pattern.regexp("hello.world", case_sensitive: false, multiline: true)
-    assert_equal /hello.world/im, pattern.regexp
+    pattern = Goodcheck::Pattern::Regexp.new(source: "hello.world", case_sensitive: false, multiline: true)
     assert_equal "hello.world", pattern.source
+    assert_equal /hello.world/im, pattern.regexp
   end
 
   def test_tokens
-    pattern = Goodcheck::Pattern.token("hello.world", case_sensitive: true)
-    assert_equal /\bhello\s*\.\s*world\b/m, pattern.regexp
+    pattern = Goodcheck::Pattern::Token.new(source: "hello.world", case_sensitive: true)
     assert_equal "hello.world", pattern.source
+    assert_equal /\bhello\s*\.\s*world\b/m, pattern.regexp
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,9 +12,9 @@ require "tmpdir"
 
 module Assertions
   def assert_pattern(object, regexp: nil, source: nil)
-    assert_instance_of Goodcheck::Pattern, object
-    assert_equal regexp, object.regexp if regexp
+    assert object.is_a?(Goodcheck::Pattern::Token) || object.is_a?(Goodcheck::Pattern::Literal) || object.is_a?(Goodcheck::Pattern::Regexp)
     assert_equal source, object.source if source
+    assert_equal regexp, object.regexp if regexp
   end
 end
 


### PR DESCRIPTION
Add a feature to capture a substring in a token pattern. This allows writing easily a really frequent pattern; *You shouldn't use other than the following*.

```yaml
rules:
  - id: bgcolor
    message: |
      You shouldn't use colors other than ones defined in our global color palette
    pattern:
      - token: bgcolor=${color:string}
        where:
          color:
            not:
              - primary.main
              - secondary.main
              - error.main
              - text.primary
```

The `${<name>:<type>}` is compiled to a regexp, and the part will be captured and tested during analysis.