### PR TITLE
Fix variable pattern without type

### DIFF
--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -605,7 +605,7 @@ EOF
       )
 
       assert_instance_of Pattern::Token, pattern
-      assert_equal /\bbgcolor\s*=\s*\{\s*(?-mix:(?-mix:"(?<color>(?:[^"]|\")*)")|(?-mix:'(?<color>(?:[^']|\')*)'))\s*\}/m, pattern.regexp
+      assert_equal /\bbgcolor\s*=\s*\{(?-mix:(?-mix:"(?<color>(?:[^"]|\")*)")|(?-mix:'(?<color>(?:[^']|\')*)'))\}/m, pattern.regexp
       assert_equal [:color], pattern.variables.keys
       pattern.variables[:color].tap do |color|
         assert_equal ["pink"], color.patterns


### PR DESCRIPTION
It generates a shortest-match-regexp. This works well if you specify the start and end characters.

```
token: background: url(${url});
where:
  size: true
```

If the predecessor and successor are open and close parens, it supports nesting up to five-levels.

```
token: backgroundColor={${color}}
where:
  color: true
```

The `${color}` can be something like `{ r: r(), g: g(), b: b(), a() }`, it has 1-level nesting of `{` and `}`.
