### PR TITLE
Run docs generation on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ rvm:
   - 2.4.7
   - 2.5.6
   - 2.6.4
+script:
+  - bundle exec rake
+  - bundle exec rake docs:build
+branches:
+  only:
+    - master

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,23 @@ namespace :docker do
     sh 'docker', 'build', '-t', 'sider/goodcheck:dev', '.'
   end
 end
+
+namespace :docs do
+  desc "Install dependencies for the documentation website"
+  task :install_deps do
+    on_docs_dir do
+      sh "yarn install"
+    end
+  end
+
+  desc "Build the documentation website"
+  task :build => [:install_deps] do
+    on_docs_dir do
+      sh "yarn run build"
+    end
+  end
+
+  def on_docs_dir(&block)
+    Dir.chdir "docusaurus/website", &block
+  end
+end


### PR DESCRIPTION
This adds two Rake tasks below:

- `docs:build`
- `docs:install_deps`

These tasks requires that Yarn is installed.