### PR TITLE
Fix `check` error on empty files

### DIFF
--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -30,7 +30,9 @@ module Goodcheck
           colored_line = line.byteslice(0, issue.location.start_column) + Rainbow(line.byteslice(issue.location.start_column, end_column - issue.location.start_column)).red + line.byteslice(end_column, line.bytesize)
           stdout.puts "#{issue.path}:#{issue.location.start_line}:#{colored_line.chomp}:\t#{issue.rule.message.lines.first.chomp}"
         else
-          stdout.puts "#{issue.path}:-:#{issue.buffer.line(1).chomp}:\t#{issue.rule.message.lines.first.chomp}"
+          line = issue.buffer.line(1)&.chomp
+          line = line ? Rainbow(line).red : '-'
+          stdout.puts "#{issue.path}:-:#{line}:\t#{issue.rule.message.lines.first.chomp}"
         end
       end
     end

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -251,10 +251,10 @@ MSG
 rules:
   - id: foo
     message: Foo
-    pattern: 
+    pattern:
       - token: "background-color: ${color:word};"
         where:
-          color: 
+          color:
             - /ink/
             - gray
 EOF
@@ -518,6 +518,27 @@ EOF
                          justifications: []
                        }
                      ], JSON.parse(stdout.string, symbolize_names: true)
+      end
+    end
+  end
+
+  def test_not_pattern_on_empty_file
+    TestCaseBuilder.tmpdir do |builder|
+      builder.cd do
+        reporter = Reporters::Text.new(stdout: stdout)
+        builder.file name: Pathname("x.js"), content: ""
+        builder.config content: <<EOF
+rules:
+  - id: strict-mode
+    not:
+      pattern: use strict
+    message: Use *strict mode* if possible.
+EOF
+
+        Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("x.js")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
+          assert_equal 2, check.run
+          assert_equal "x.js:-:-:\tUse *strict mode* if possible.\n", stdout.string
+        end
       end
     end
   end


### PR DESCRIPTION
Fix #72