### PR TITLE
Fix Ruby warnings

### DIFF
--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"
   spec.add_runtime_dependency "rainbow", "~> 3.0.0"
   spec.add_runtime_dependency "httpclient", "~> 2.8.3"
+  spec.add_runtime_dependency "psych", ">= 3.1", "< 4.0"
 end

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"
   spec.add_runtime_dependency "rainbow", "~> 3.0.0"
   spec.add_runtime_dependency "httpclient", "~> 2.8.3"
-  spec.add_runtime_dependency "psych", ">= 3.1", "< 4.0"
+  spec.add_runtime_dependency "psych", ">= 3.1", "< 4.0" # NOTE: Needed for old Ruby versions (<= 2.5)
 end

--- a/lib/goodcheck/buffer.rb
+++ b/lib/goodcheck/buffer.rb
@@ -6,6 +6,7 @@ module Goodcheck
     def initialize(path:, content:)
       @path = path
       @content = content
+      @line_ranges = nil
     end
 
     def line_ranges

--- a/lib/goodcheck/commands/config_loading.rb
+++ b/lib/goodcheck/commands/config_loading.rb
@@ -5,7 +5,7 @@ module Goodcheck
 
       def load_config!(force_download:, cache_path:)
         import_loader = ImportLoader.new(cache_path: cache_path, force_download: force_download, config_path: config_path)
-        content = JSON.parse(JSON.dump(YAML.load(config_path.read, config_path.to_s)), symbolize_names: true)
+        content = JSON.parse(JSON.dump(YAML.load(config_path.read, filename: config_path.to_s)), symbolize_names: true)
         loader = ConfigLoader.new(path: config_path, content: content, stderr: stderr, import_loader: import_loader)
         @config = loader.load
       end

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -241,7 +241,7 @@ module Goodcheck
 
       Goodcheck.logger.tagged import do
         import_loader.load(import) do |content|
-          json = JSON.parse(JSON.dump(YAML.load(content, import)), symbolize_names: true)
+          json = JSON.parse(JSON.dump(YAML.load(content, filename: import)), symbolize_names: true)
 
           Schema.rules.coerce json
           load_rules(rules, json)

--- a/lib/goodcheck/issue.rb
+++ b/lib/goodcheck/issue.rb
@@ -10,6 +10,7 @@ module Goodcheck
       @range = range
       @rule = rule
       @text = text
+      @location = nil
     end
 
     def path

--- a/lib/goodcheck/trigger.rb
+++ b/lib/goodcheck/trigger.rb
@@ -12,6 +12,8 @@ module Goodcheck
       @passes = passes
       @fails = fails
       @negated = negated
+      @by_pattern = false
+      @skips_fail_examples = false
     end
 
     def by_pattern!

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -176,7 +176,7 @@ EOF
 
         assert_equal 1, check.run
 
-        assert_match /Unexpected error happens while loading YAML file: #<Psych::SyntaxError:/, stderr.string
+        assert_match %r(Unexpected error happens while loading YAML file: #<Psych::SyntaxError:), stderr.string
       end
     end
   end
@@ -366,7 +366,7 @@ EOF
 
         assert_equal 1, check.run
 
-        assert_match /No such file or directory @ rb_sysopen/, stderr.string
+        assert_match %r(No such file or directory @ rb_sysopen), stderr.string
       end
     end
   end
@@ -386,15 +386,15 @@ EOF
         Check.new(config_path: builder.config_path.basename, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
 
-          assert_match /README.md/, stdout.string
-          refute_match /goodcheck.yml/, stdout.string
+          assert_match %r(README\.md), stdout.string
+          refute_match %r(goodcheck\.yml), stdout.string
         end
 
         Check.new(config_path: builder.config_path.basename, rules: [], targets: [Pathname("."), Pathname("goodcheck.yml")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
 
-          assert_match /README.md/, stdout.string
-          assert_match /goodcheck.yml/, stdout.string
+          assert_match %r(README\.md), stdout.string
+          assert_match %r(goodcheck\.yml), stdout.string
         end
       end
     end
@@ -414,12 +414,12 @@ EOF
 
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
-          refute_match /\.file/, stdout.string
+          refute_match %r(\.file), stdout.string
         end
 
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("."), Pathname(".file")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
-          assert_match /\.file/, stdout.string
+          assert_match %r(\.file), stdout.string
         end
       end
     end

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -266,7 +266,7 @@ class ConfigLoaderTest < Minitest::Test
                        ]
                      })
 
-    assert_match /`case_insensitive` option is deprecated/, stderr.string
+    assert_match %r(`case_insensitive` option is deprecated), stderr.string
     assert_equal 1, stderr.string.scan(/`case_insensitive` option is deprecated/).count
   end
 
@@ -605,7 +605,7 @@ EOF
       )
 
       assert_instance_of Pattern::Token, pattern
-      assert_equal /\bbgcolor\s*=\s*\{(?-mix:(?-mix:"(?<color>(?:[^"]|\")*)")|(?-mix:'(?<color>(?:[^']|\')*)'))\}/m, pattern.regexp
+      assert_equal %r(\bbgcolor\s*=\s*\{(?-mix:(?-mix:"(?<color>(?:[^"]|\")*)")|(?-mix:'(?<color>(?:[^']|\')*)'))\})m, pattern.regexp
       assert_equal [:color], pattern.variables.keys
       pattern.variables[:color].tap do |color|
         assert_equal ["pink"], color.patterns

--- a/test/init_command_test.rb
+++ b/test/init_command_test.rb
@@ -12,7 +12,7 @@ class InitCommandTest < Minitest::Test
 
         assert_equal 0, init.run
 
-        assert_match /Wrote goodcheck\.yml/, stdout.string
+        assert_match %r(Wrote goodcheck\.yml), stdout.string
         assert_operator Pathname("goodcheck.yml"), :file?
         YAML.load(Pathname("goodcheck.yml").read)
       end
@@ -27,7 +27,7 @@ class InitCommandTest < Minitest::Test
         init = Init.new(stdout: stdout, stderr: stderr, path: Pathname("goodcheck.yml"), force: false)
 
         assert_equal 1, init.run
-        assert_match /goodcheck\.yml already exists\./, stderr.string
+        assert_match %r(goodcheck\.yml already exists\.), stderr.string
 
         assert_equal({ "rules" => [] }, YAML.load(Pathname("goodcheck.yml").read))
       end
@@ -42,7 +42,7 @@ class InitCommandTest < Minitest::Test
         init = Init.new(stdout: stdout, stderr: stderr, path: Pathname("goodcheck.yml"), force: true)
 
         assert_equal 0, init.run
-        assert_match /Wrote goodcheck\.yml/, stdout.string
+        assert_match %r(Wrote goodcheck\.yml), stdout.string
         refute_equal({ "rules" => [] }, YAML.load(Pathname("goodcheck.yml").read))
       end
     end

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -124,11 +124,11 @@ class PatternTest < Minitest::Test
 
   def test_tokenize_variable_word2
     Token.compile_tokens("foo ${color:word}", { color: Token::VarPattern.empty }, case_sensitive: true).tap do |regexp|
-      assert_equal /\bfoo\s+(?-mix:(?<color>\S+))/m, regexp
+      assert_equal %r{\bfoo\s+(?-mix:(?<color>\S+))}m, regexp
     end
 
     Token.compile_tokens("${color:word} foo", { color: Token::VarPattern.empty }, case_sensitive: true).tap do |regexp|
-      assert_equal /(?-mix:(?<color>\S+))\s+foo\b/m, regexp
+      assert_equal %r{(?-mix:(?<color>\S+))\s+foo\b}m, regexp
     end
   end
 
@@ -178,19 +178,19 @@ class PatternTest < Minitest::Test
   def test_literal
     pattern = Literal.new(source: "hello.world", case_sensitive: false)
     assert_equal "hello.world", pattern.source
-    assert_equal /hello\.world/i, pattern.regexp
+    assert_equal %r(hello\.world)i, pattern.regexp
   end
 
   def test_regexp
     pattern = Regexp.new(source: "hello.world", case_sensitive: false, multiline: true)
     assert_equal "hello.world", pattern.source
-    assert_equal /hello.world/im, pattern.regexp
+    assert_equal %r(hello.world)im, pattern.regexp
   end
 
   def test_tokens
     pattern = Token.new(source: "hello.world", variables: {}, case_sensitive: true)
     assert_equal "hello.world", pattern.source
-    assert_equal /\bhello\s*\.\s*world\b/m, pattern.regexp
+    assert_equal %r(\bhello\s*\.\s*world\b)m, pattern.regexp
   end
 
   def test_tokens_var

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -14,7 +14,7 @@ class SmokeTest < Minitest::Test
       stdout, _, status = shell(goodcheck, chdir: builder.path)
 
       assert_operator status, :success?
-      assert_match /#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}/, stdout
+      assert_match %r(#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}), stdout
     end
   end
 
@@ -23,7 +23,7 @@ class SmokeTest < Minitest::Test
       stdout, _, status = shell(goodcheck, "help", chdir: builder.path)
 
       assert_operator status, :success?
-      assert_match /#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}/, stdout
+      assert_match %r(#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}), stdout
     end
   end
 
@@ -32,7 +32,7 @@ class SmokeTest < Minitest::Test
       stdout, _, status = shell(goodcheck, "version", chdir: builder.path)
 
       assert_operator status, :success?
-      assert_match /#{Regexp.escape "goodcheck #{Goodcheck::VERSION}"}/, stdout
+      assert_match %r(#{Regexp.escape "goodcheck #{Goodcheck::VERSION}"}), stdout
     end
   end
 


### PR DESCRIPTION
You can see the warnings via `bundle exec rake` command.

- `Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.`
- `warning: instance variable @location not initialized`

See the Travis [build log](https://travis-ci.org/sider/goodcheck/jobs/609092842#L269) for details.