### PR TITLE
Improve publishing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,10 @@ To release a new version, follows the steps below:
 
 1. Update the version number in [`version.rb`](lib/goodcheck/version.rb).
 2. Add the new version's entry to the [changelog](CHANGELOG.md).
-3. Commit the above changes like `git commit -m 'Version 1.2.3'`.
-4. Run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+3. Update the documentation via `bundle exec rake docs:update_version`.
+4. Commit the above changes like `git commit -m 'Version 1.2.3'`.
+5. Run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+6. Publish the updated documentation like `GIT_USER=some_user USE_SSH=true bundle exec rake docs:publish`.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,13 @@ namespace :docs do
     end
   end
 
+  desc "Publish the documentation website"
+  task :publish => [:build] do
+    on_docs_dir do
+      sh "yarn", "run", "publish-gh-pages"
+    end
+  end
+
   def on_docs_dir(&block)
     Dir.chdir "docusaurus/website", &block
   end


### PR DESCRIPTION
- Add `rake docs:publish`.
- Update the releasing instructions in README.