### PR TITLE
Add `n` option to `benchmark:run` task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           ruby-version: 2.7
       - run: bundle install --jobs=4 --retry=3 --path=vendor/bundle
-      - run: bundle exec rake benchmark:run
+      - run: bundle exec rake benchmark:run[10000]

--- a/Rakefile
+++ b/Rakefile
@@ -51,14 +51,16 @@ end
 
 namespace :benchmark do
   desc "Run benchmark"
-  task :run do
+  task :run, [:n] do |_task, args|
     require "benchmark"
     require_relative "lib/goodcheck"
     require_relative "lib/goodcheck/cli"
 
     target_file = File.join(__dir__, "benchmark", "gc.c")
 
-    n = 100
+    n = Integer(args[:n] || 1000)
+    puts "n = #{n}"
+
     Benchmark.bm do |x|
       x.report do
         n.times { Goodcheck::CLI.new(stdout: STDOUT, stderr: STDERR).run(["check", target_file]) }


### PR DESCRIPTION
Usage:

```shell
rake benchmark:run # default: n=1000
```

Or,

```shell
rake benchmark:run[10000]
```