### PR TITLE
Simplify test workflows on Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: |
-          gem install bundler --no-document
-          bundle config set path vendor/bundle
-          bundle install --jobs=4 --retry=3
+      - run: bundle install
       - run: bundle exec rake
 
   build-docs:
@@ -26,10 +23,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - run: |
-          gem install bundler --no-document
-          bundle config set path vendor/bundle
-          bundle install --jobs=4 --retry=3
+      - run: bundle install
       - run: bundle exec rake docs:build
 
   bench:
@@ -39,8 +33,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - run: |
-          gem install bundler --no-document
-          bundle config set path vendor/bundle
-          bundle install --jobs=4 --retry=3
+      - run: bundle install
       - run: bundle exec rake bench


### PR DESCRIPTION
`ruby/setup-ruby` runs the `gem install bundler` and `bundle config` commands,
so this change removes these needless commands.

- https://github.com/ruby/setup-ruby/blob/8bc9ca9ace0139aae24423f15269b9673354b495/index.js#L234
- https://github.com/ruby/setup-ruby/blob/8bc9ca9ace0139aae24423f15269b9673354b495/index.js#L250