### PR TITLE
Refactor tests

### DIFF
--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class AnalyzerTest < Minitest::Test
   Analyzer = Goodcheck::Analyzer

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class BufferTest < Minitest::Test
   Buffer = Goodcheck::Buffer
@@ -56,7 +56,7 @@ ipsum
 
   def test_disabled_line
     buffer = Buffer.new(path: Pathname("a.txt"), content: <<-EOF
-    Lorem 
+    Lorem
     ipsum # goodcheck-disable-line
     吾輩は猫である。
     # goodcheck-disable-next-line

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class CheckCommandTest < Minitest::Test
   include Outputs

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class ConfigLoaderTest < Minitest::Test
   include Assertions

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class ConfigTest < Minitest::Test
   ConfigLoader = Goodcheck::ConfigLoader

--- a/test/import_loader_test.rb
+++ b/test/import_loader_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class ImportLoaderTest < Minitest::Test
   include TestHelper

--- a/test/init_command_test.rb
+++ b/test/init_command_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class InitCommandTest < Minitest::Test
   include Outputs

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class JSONReporterTest < Minitest::Test
   Reporters = Goodcheck::Reporters

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class PatternTest < Minitest::Test
   Token = Goodcheck::Pattern::Token

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class SmokeTest < Minitest::Test
   def goodcheck

--- a/test/test_command_test.rb
+++ b/test/test_command_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 
 class TestCommandTest < Minitest::Test
   Test = Goodcheck::Commands::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "goodcheck"
 
 require "minitest/autorun"


### PR DESCRIPTION
- Simplify `require "test_helper"`
- Remove needless `$LOADPATH` setting