### PR TITLE
Improve CLI help and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Improve CLI help and error messages [#141](https://github.com/sider/goodcheck/pull/141)
+
 ## 2.5.2 (2020-08-31)
 
 * Fix the pattern of disable lines for Slash-asterisk and add support for JSX [#131](https://github.com/sider/goodcheck/pull/131)

--- a/lib/goodcheck.rb
+++ b/lib/goodcheck.rb
@@ -13,7 +13,7 @@ require "net/http"
 require "goodcheck/version"
 require "goodcheck/logger"
 require "goodcheck/home_path"
-
+require "goodcheck/exit_status"
 require "goodcheck/glob"
 require "goodcheck/buffer"
 require "goodcheck/location"

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -13,6 +13,9 @@ module Goodcheck
 
       include ConfigLoading
       include HomePath
+      include ExitStatus
+
+      EXIT_MATCH = 2
 
       def initialize(config_path:, rules:, targets:, reporter:, stderr:, home_path:, force_download:)
         @config_path = config_path
@@ -46,7 +49,7 @@ module Goodcheck
             end
           end
 
-          issue_reported ? 2 : 0
+          issue_reported ? EXIT_MATCH : EXIT_SUCCESS
         end
       end
 

--- a/lib/goodcheck/commands/init.rb
+++ b/lib/goodcheck/commands/init.rb
@@ -58,6 +58,8 @@ rules:
 #   - vendor
       EOC
 
+      include ExitStatus
+
       attr_reader :stdout
       attr_reader :stderr
       attr_reader :path
@@ -73,7 +75,7 @@ rules:
       def run
         if path.file? && !force
           stderr.puts "#{path} already exists. Try --force option to overwrite the file."
-          return 1
+          return EXIT_ERROR
         end
 
         path.open("w") do |io|
@@ -82,7 +84,7 @@ rules:
 
         stdout.puts "Wrote #{path}. ✍️"
 
-        0
+        EXIT_SUCCESS
       end
     end
   end

--- a/lib/goodcheck/commands/pattern.rb
+++ b/lib/goodcheck/commands/pattern.rb
@@ -9,6 +9,7 @@ module Goodcheck
 
       include ConfigLoading
       include HomePath
+      include ExitStatus
 
       def initialize(stdout:, stderr:, path:, ids:, home_path:)
         @stdout = stdout
@@ -34,7 +35,7 @@ module Goodcheck
           end
         end
 
-        0
+        EXIT_SUCCESS
       end
     end
   end

--- a/lib/goodcheck/commands/test.rb
+++ b/lib/goodcheck/commands/test.rb
@@ -3,6 +3,7 @@ module Goodcheck
     class Test
       include ConfigLoading
       include HomePath
+      include ExitStatus
 
       attr_reader :stdout
       attr_reader :stderr
@@ -24,13 +25,13 @@ module Goodcheck
 
           if config.rules.empty?
             stdout.puts "No rules."
-            return 0
+            return EXIT_SUCCESS
           end
 
-          validate_rule_uniqueness or return 1
-          validate_rules or return 1
+          validate_rule_uniqueness or return EXIT_ERROR
+          validate_rules or return EXIT_ERROR
 
-          0
+          EXIT_SUCCESS
         end
       end
 

--- a/lib/goodcheck/exit_status.rb
+++ b/lib/goodcheck/exit_status.rb
@@ -1,0 +1,6 @@
+module Goodcheck
+  module ExitStatus
+    EXIT_SUCCESS = 0
+    EXIT_ERROR = 1
+  end
+end


### PR DESCRIPTION
- Add option messages for each sub-command.
- Reduce duplicate or needless code.

For example:

```console
$ goodcheck check -h
Usage: goodcheck check [options] paths...
    -c, --config=CONFIG              Configuration file path [default: 'goodcheck.yml']
    -v, --verbose                    Set log level to verbose
    -d, --debug                      Set log level to debug
        --force                      Download importing files always
    -R, --rule=RULE                  Only rule(s) to check
        --format=<text|json>         Output format [default: 'text']
        --version                    Print version
    -h, --help                       Show help and quit
```