### PR TITLE
Fail if missing rules on `goodcheck check` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Improve CLI help and error messages [#141](https://github.com/sider/goodcheck/pull/141)
+* Fail if missing rules on `goodcheck check` command [#142](https://github.com/sider/goodcheck/pull/142)
 
 ## 2.5.2 (2020-08-31)
 

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -33,6 +33,14 @@ module Goodcheck
 
           reporter.analysis do
             load_config!(force_download: force_download, cache_path: cache_dir_path)
+
+            unless missing_rules.empty?
+              missing_rules.each do |rule|
+                stderr.puts "missing rule: #{rule}"
+              end
+              return EXIT_ERROR
+            end
+
             each_check do |buffer, rule, trigger|
               reported_issues = Set[]
 
@@ -50,6 +58,13 @@ module Goodcheck
           end
 
           issue_reported ? EXIT_MATCH : EXIT_SUCCESS
+        end
+      end
+
+      def missing_rules
+        @missing_rules ||= begin
+          config_rule_ids = config.rules.map(&:id)
+          rules.select { |rule| !config_rule_ids.include?(rule) }
         end
       end
 

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -64,7 +64,7 @@ module Goodcheck
       def missing_rules
         @missing_rules ||= begin
           config_rule_ids = config.rules.map(&:id)
-          rules.select { |rule| !config_rule_ids.include?(rule) }
+          rules.reject { |rule| config_rule_ids.include?(rule) }
         end
       end
 

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -641,4 +641,24 @@ EOF
       end
     end
   end
+
+  def test_missing_rule
+    TestCaseBuilder.tmpdir do |builder|
+      builder.cd do
+        builder.config content: <<-EOF
+rules:
+  - id: foo
+    message: Foo
+    pattern: foo
+EOF
+
+        reporter = Reporters::Text.new(stdout: stdout)
+        check = Check.new(config_path: builder.config_path, rules: ["foo", "bar", "baz"], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
+
+        assert_equal 1, check.run
+        assert_equal "missing rule: bar\nmissing rule: baz\n", stderr.string
+        assert_empty stdout.string
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix #125