### PR TITLE
Reduce needless files in this gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Improve CLI help and error messages [#141](https://github.com/sider/goodcheck/pull/141)
 * Fail if missing rules on `goodcheck check` command [#142](https://github.com/sider/goodcheck/pull/142)
+* Reduce needless files in this gem [#143](https://github.com/sider/goodcheck/pull/143)
 
 ## 2.5.2 (2020-08-31)
 

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -1,5 +1,5 @@
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "goodcheck/version"
 
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sider/goodcheck"
   spec.licenses      = ["MIT"]
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "exe/goodcheck", "lib/**/*.rb"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This change aims to:

- reduce this gem size
- make diffend.io view more useful (see <https://my.diffend.io/gems/goodcheck/2.5.1/2.5.2>)

---

```console
$ du -hs goodcheck-2.5.2.gem*
 28K	goodcheck-2.5.2.gem
820K	goodcheck-2.5.2.gem.before
```

---

Run: `gem build && gem unpack goodcheck-2.5.2.gem && tree goodcheck-2.5.2`

### Before

```
goodcheck-2.5.2
├── CHANGELOG.md
├── Dockerfile
├── Gemfile
├── LICENSE
├── README.md
├── Rakefile
├── bin
│   ├── console
│   └── setup
├── cheatsheet.pdf
├── docusaurus
│   ├── Dockerfile
│   ├── docker-compose.yml
│   ├── docs
│   │   ├── commands.md
│   │   ├── configuration.md
│   │   ├── development.md
│   │   ├── getstarted.md
│   │   └── rules.md
│   └── website
│       ├── README.md
│       ├── core
│       │   └── Footer.js
│       ├── package.json
│       ├── pages
│       │   └── en
│       │       ├── index.js
│       │       └── versions.js
│       ├── sidebars.json
│       ├── siteConfig.js
│       ├── static
│       │   ├── css
│       │   │   ├── code-block-buttons.css
│       │   │   └── custom.css
│       │   ├── img
│       │   │   └── favicon.ico
│       │   └── js
│       │       └── code-block-buttons.js
│       ├── versioned_docs
│       │   ├── version-1.0.0
│       │   │   ├── commands.md
│       │   │   ├── configuration.md
│       │   │   ├── development.md
│       │   │   ├── getstarted.md
│       │   │   └── rules.md
│       │   ├── version-1.0.2
│       │   │   └── rules.md
│       │   ├── version-2.4.0
│       │   │   └── configuration.md
│       │   └── version-2.4.3
│       │       └── rules.md
│       ├── versioned_sidebars
│       │   ├── version-1.0.0-sidebars.json
│       │   ├── version-1.0.2-sidebars.json
│       │   └── version-2.4.0-sidebars.json
│       ├── versions.json
│       └── yarn.lock
├── exe
│   └── goodcheck
├── goodcheck.gemspec
├── goodcheck.yml
├── lib
│   ├── goodcheck
│   │   ├── analyzer.rb
│   │   ├── array_helper.rb
│   │   ├── buffer.rb
│   │   ├── cli.rb
│   │   ├── commands
│   │   │   ├── check.rb
│   │   │   ├── config_loading.rb
│   │   │   ├── init.rb
│   │   │   ├── pattern.rb
│   │   │   └── test.rb
│   │   ├── config.rb
│   │   ├── config_loader.rb
│   │   ├── exit_status.rb
│   │   ├── glob.rb
│   │   ├── home_path.rb
│   │   ├── import_loader.rb
│   │   ├── issue.rb
│   │   ├── location.rb
│   │   ├── logger.rb
│   │   ├── pattern.rb
│   │   ├── reporters
│   │   │   ├── json.rb
│   │   │   └── text.rb
│   │   ├── rule.rb
│   │   ├── trigger.rb
│   │   └── version.rb
│   └── goodcheck.rb
├── logo
│   ├── GoodCheck\ Horizontal.pdf
│   ├── GoodCheck\ Horizontal.png
│   ├── GoodCheck\ Horizontal.svg
│   ├── GoodCheck\ logo.png
│   └── GoodCheck\ vertical.png
└── sample.yml

23 directories, 74 files
```

### After

```
goodcheck-2.5.2
├── CHANGELOG.md
├── LICENSE
├── README.md
├── exe
│   └── goodcheck
└── lib
    ├── goodcheck
    │   ├── analyzer.rb
    │   ├── array_helper.rb
    │   ├── buffer.rb
    │   ├── cli.rb
    │   ├── commands
    │   │   ├── check.rb
    │   │   ├── config_loading.rb
    │   │   ├── init.rb
    │   │   ├── pattern.rb
    │   │   └── test.rb
    │   ├── config.rb
    │   ├── config_loader.rb
    │   ├── exit_status.rb
    │   ├── glob.rb
    │   ├── home_path.rb
    │   ├── import_loader.rb
    │   ├── issue.rb
    │   ├── location.rb
    │   ├── logger.rb
    │   ├── pattern.rb
    │   ├── reporters
    │   │   ├── json.rb
    │   │   └── text.rb
    │   ├── rule.rb
    │   ├── trigger.rb
    │   └── version.rb
    └── goodcheck.rb

5 directories, 29 files
```
