### PR TITLE
Add `Goodcheck::Error` as a base error class

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,3 +1,10 @@
+rules:
+  - id: sider.goodcheck.error_class
+    pattern: StandardError
+    glob: "lib/**/*.rb"
+    message: |
+      Use `GoodCheck::Error` instead of `StandardError`.
+
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/ruby.yml

--- a/lib/goodcheck.rb
+++ b/lib/goodcheck.rb
@@ -11,6 +11,7 @@ require "digest/sha2"
 require "net/http"
 
 require "goodcheck/version"
+require "goodcheck/error"
 require "goodcheck/logger"
 require "goodcheck/home_path"
 require "goodcheck/exit_status"

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -2,7 +2,7 @@ module Goodcheck
   class ConfigLoader
     include ArrayHelper
 
-    class InvalidPattern < StandardError; end
+    class InvalidPattern < Error; end
 
     Schema = StrongJSON.new do
       def self.array_or(type)

--- a/lib/goodcheck/error.rb
+++ b/lib/goodcheck/error.rb
@@ -1,0 +1,3 @@
+module Goodcheck
+  class Error < StandardError; end
+end

--- a/lib/goodcheck/import_loader.rb
+++ b/lib/goodcheck/import_loader.rb
@@ -1,6 +1,6 @@
 module Goodcheck
   class ImportLoader
-    class UnexpectedSchemaError < StandardError
+    class UnexpectedSchemaError < Error
       attr_reader :uri
 
       def initialize(uri)


### PR DESCRIPTION
This change allows to rescue all errors in Goodcheck as follows:

```ruby
begin
  # some logic...
rescue Goodcheck::Error => error
  # some error handling...
end
```