### PR TITLE
Improve error message when config file is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fail if missing rules on `goodcheck check` command [#142](https://github.com/sider/goodcheck/pull/142)
 * Reduce needless files in this gem [#143](https://github.com/sider/goodcheck/pull/143)
 * Add `Goodcheck::Error` as a base error class [#144](https://github.com/sider/goodcheck/pull/144)
+* Improve error message when config file is not found [#145](https://github.com/sider/goodcheck/pull/145)
 
 ## 2.5.2 (2020-08-31)
 

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -362,11 +362,10 @@ EOF
     TestCaseBuilder.tmpdir do |builder|
       builder.cd do
         reporter = Reporters::Text.new(stdout: stdout)
-        check = Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
+        check = Check.new(config_path: Pathname("foo.yml"), rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home")
 
         assert_equal 1, check.run
-
-        assert_match %r(No such file or directory @ rb_sysopen), stderr.string
+        assert_equal "Configuration file not found: foo.yml\n", stderr.string
       end
     end
   end

--- a/test/test_command_test.rb
+++ b/test/test_command_test.rb
@@ -192,4 +192,15 @@ Tested 1 rule, 0 successes, 1 failure
 MSG
     end
   end
+
+  def test_no_config
+    TestCaseBuilder.tmpdir do |builder|
+      builder.cd do
+        test = Test.new(stdout: stdout, stderr: stderr, config_path: Pathname("foo.yml"), force_download: nil, home_path: builder.path + "home")
+
+        assert_equal 1, test.run
+        assert_equal "Configuration file not found: foo.yml\n", stderr.string
+      end
+    end
+  end
 end


### PR DESCRIPTION
For example:

```console
$ goodcheck test --config foo.yml
Configuration file not found: foo.yml

$ goodcheck check --config foo.yml
Configuration file not found: foo.yml
```

Fix #121