### PR TITLE
Add `rules[].glob.exclude` option to `goodcheck.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reduce needless files in this gem [#143](https://github.com/sider/goodcheck/pull/143)
 * Add `Goodcheck::Error` as a base error class [#144](https://github.com/sider/goodcheck/pull/144)
 * Improve error message when config file is not found [#145](https://github.com/sider/goodcheck/pull/145)
+* Add `rules[].glob.exclude` option to `goodcheck.yml` [#146](https://github.com/sider/goodcheck/pull/146)
 
 ## 2.5.2 (2020-08-31)
 

--- a/docusaurus/docs/configuration.md
+++ b/docusaurus/docs/configuration.md
@@ -169,12 +169,16 @@ A *glob* can be a string, or a hash.
 glob:
   pattern: "legacy/**/*.rb"
   encoding: EUC-JP
+  exclude: ["**/test/**", "**/spec/**"]
 ```
 
 The hash can have an optional `encoding` attribute.
 You can specify the encoding of the file by the names defined for Ruby.
 The list of all available encoding names can be found by `$ ruby -e "puts Encoding.name_list"`.
 The default value is `UTF-8`.
+
+Also, the hash can have an optional `exclude` attribute.
+You can exclude any files from the `pattern` matched ones by this attribute.
 
 If you write a string as a `glob`, the string value can be the `pattern` of the glob, without `encoding` attribute.
 

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -22,7 +22,8 @@ module Goodcheck
       let :deprecated_token_pattern, object(token: string, case_insensitive: boolean?)
 
       let :encoding, enum(*Encoding.name_list.map {|name| literal(name) })
-      let :glob_obj, object(pattern: string, encoding: optional(encoding))
+      let :glob_obj, object(pattern: string, encoding: optional(encoding),
+                            exclude: enum?(string, array(string)))
       let :one_glob, enum(glob_obj,
                           string,
                           detector: -> (value) {
@@ -344,9 +345,9 @@ module Goodcheck
       globs.map do |glob|
         case glob
         when String
-          Glob.new(pattern: glob, encoding: nil)
+          Glob.new(pattern: glob, encoding: nil, exclude: nil)
         when Hash
-          Glob.new(pattern: glob[:pattern], encoding: glob[:encoding])
+          Glob.new(pattern: glob[:pattern], encoding: glob[:encoding], exclude: glob[:exclude])
         end
       end
     end

--- a/lib/goodcheck/glob.rb
+++ b/lib/goodcheck/glob.rb
@@ -1,21 +1,32 @@
 module Goodcheck
   class Glob
+    FNM_FLAGS = File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH
+
     attr_reader :pattern
     attr_reader :encoding
+    attr_reader :exclude
 
-    def initialize(pattern:, encoding:)
+    def initialize(pattern:, encoding:, exclude:)
       @pattern = pattern
       @encoding = encoding
+      @exclude = exclude
     end
 
     def test(path)
-      path.fnmatch?(pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH)
+      path.fnmatch?(pattern, FNM_FLAGS) && !excluded?(path)
     end
 
     def ==(other)
       other.is_a?(Glob) &&
         other.pattern == pattern &&
-        other.encoding == encoding
+        other.encoding == encoding &&
+        other.exclude == exclude
+    end
+
+    private
+
+    def excluded?(path)
+      Array(exclude).any? { |exc| path.fnmatch?(exc, FNM_FLAGS) }
     end
   end
 end

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -241,7 +241,7 @@ atest
         buffer: buffer,
         rule: new_rule(id: "rule1"),
         trigger: new_trigger {|trigger|
-          trigger.globs << Goodcheck::Glob.new(pattern: "*.txt", encoding: nil)
+          trigger.globs << Goodcheck::Glob.new(pattern: "*.txt", encoding: nil, exclude: nil)
         }
       )
 

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -120,6 +120,7 @@ rules:
       - bar
     glob:
       - "app/models/**/*.rb"
+      - { pattern: "**/*.erb", exclude: "**/*.html.*" }
 EOF
 
       builder.file name: Pathname("app/models/user.rb"), content: <<EOF
@@ -129,13 +130,14 @@ end
 EOF
 
       builder.file name: Pathname("app/views/welcome/index.html.erb"), content: <<EOF
-<h1>Foo Bar Baz</h1>
+<h1>Foo bar Baz</h1>
 EOF
 
       stdout, _, status = shell(goodcheck, "check", ".", chdir: builder.path)
 
       refute status.success?
       assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout
+      refute_match %r(app/views/welcome/index\.html\.erb:1:), stdout
     end
   end
 


### PR DESCRIPTION
For example:

```yaml
# goodcheck.yml
rules:
  - id: example1
    pattern: foo
    message: Disallow "foo"
    glob:
      - { pattern: "**/*.html", exclude: "**/test/**" }
      - { pattern: "**/*.txt", exclude: ["**/test/**", "**/spec/**"] }
```

Fix #119