### PR TITLE
Improve workflows on Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,19 @@
 name: Release
 
-on: push
+on:
+  push:
+    tags: ["**"]
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+        id: get_tag
       - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body: |
-            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/CHANGELOG.md) for more details.
+            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7]
     steps:
@@ -13,7 +14,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install
+          bundler-cache: true
       - run: bundle exec rake
 
   build-docs:
@@ -23,7 +24,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - run: bundle install
+          bundler-cache: true
       - run: bundle exec rake docs:build
 
   bench:
@@ -33,5 +34,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - run: bundle install
+          bundler-cache: true
       - run: bundle exec rake bench


### PR DESCRIPTION
- Release: use a tag instead of a commit sha.
- Test: set `bundler-cache: true`