### PR TITLE
Add missing `require "set"`

### DIFF
--- a/lib/goodcheck.rb
+++ b/lib/goodcheck.rb
@@ -1,5 +1,6 @@
 require "strscan"
 require "pathname"
+require "set"
 require "strong_json"
 require "yaml"
 require "json"


### PR DESCRIPTION
`Set` is used in `Goodcheck::CLI` class:
https://github.com/sider/goodcheck/blob/b23ad97feb9c31898282a1a7394975dc82b27c09/lib/goodcheck/cli.rb#L174