### PR TITLE
Glob support for importing rules

### DIFF
--- a/lib/goodcheck/import_loader.rb
+++ b/lib/goodcheck/import_loader.rb
@@ -46,13 +46,13 @@ module Goodcheck
     end
 
     def load_file(path)
-      files = config_path.parent.glob(path, File::FNM_DOTMATCH | File::FNM_EXTGLOB).sort
+      files = Dir.glob(File.join(config_path.parent.to_path, path), File::FNM_DOTMATCH | File::FNM_EXTGLOB).sort
       if files.empty?
         raise FileNotFound.new(path)
       else
         files.each do |file|
           Goodcheck.logger.info "Reading file: #{file}"
-          yield file.read
+          yield File.read(file)
         end
       end
     end


### PR DESCRIPTION
This change allows you to write *glob* patterns for `import:` in `goodcheck.yml`.
For example:

```yaml
import:
  - "rules/**/*.yml"
  - "goodcheck-*.yml"
```

I believe this feature so useful if you want to manage many rules in some files.

Close #133