### PR TITLE
Add rake task `docs:start`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,19 @@ namespace :docs do
     end
   end
 
+  desc "Start the documentation development server"
+  task :start => [:install_deps] do
+    puts ""
+    puts "!!!"
+    puts "!!! Open the URL in your browser: http://127.0.0.1:3000/goodcheck/docs/next/getstarted"
+    puts "!!!"
+    puts ""
+
+    on_docs_dir do
+      sh "yarn", "run", "start"
+    end
+  end
+
   desc "Build the documentation website"
   task :build => [:install_deps] do
     on_docs_dir do
@@ -51,6 +64,7 @@ namespace :docs do
   end
 
   def on_docs_dir(&block)
-    Dir.chdir "docusaurus/website", &block
+    dir = File.join(__dir__, "docusaurus", "website")
+    Dir.chdir(dir, &block)
   end
 end


### PR DESCRIPTION
For the development of the documentation.

Usage:

```console
$ bundle exec rake docs:start
yarn install
yarn install v1.22.10
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.40s.

!!!
!!! Open the URL in your browser: http://127.0.0.1:3000/goodcheck/docs/next/getstarted
!!!

yarn run start
yarn run v1.22.10
warning package.json: No license field
$ docusaurus-start
LiveReload server started on port 35729
Docusaurus server started on port 3000
```