### PR TITLE
Refactor dependency constraints not to use `~>`

### DIFF
--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_development_dependency "bundler", ">= 1.16"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "minitest-reporters", "~> 1.4.2"
+  spec.add_development_dependency "rake", ">= 13.0"
+  spec.add_development_dependency "minitest", ">= 5.0"
+  spec.add_development_dependency "minitest-reporters", ">= 1.4"
 
   spec.add_runtime_dependency "activesupport", ">= 4.0", "< 7.0"
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"
-  spec.add_runtime_dependency "rainbow", "~> 3.0.0"
+  spec.add_runtime_dependency "rainbow", ">= 3.0", "< 4.0"
   spec.add_runtime_dependency "psych", ">= 3.1", "< 4.0" # NOTE: Needed for old Ruby versions (<= 2.5)
 end


### PR DESCRIPTION
`~>` is not intuitive. Instead, this uses `>=` and `<`.
The actual dependencies are unchanged.