### PR TITLE
Enable test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
       - uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+        if: ${{ always() && matrix.ruby == '2.7' }}
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 7
 
   build-docs:
     runs-on: ubuntu-latest

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "minitest", ">= 5.0"
   spec.add_development_dependency "minitest-reporters", ">= 1.4"
-  spec.add_development_dependency "simplecov", ">= 0.19"
+  spec.add_development_dependency "simplecov", ">= 0.18"
 
   spec.add_runtime_dependency "activesupport", ">= 4.0", "< 7.0"
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "minitest", ">= 5.0"
   spec.add_development_dependency "minitest-reporters", ">= 1.4"
+  spec.add_development_dependency "simplecov", ">= 0.19"
 
   spec.add_runtime_dependency "activesupport", ">= 4.0", "< 7.0"
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -11,6 +11,7 @@ import:
 
 exclude:
   - "**/build"
+  - "**/coverage"
   - "**/node_modules"
   - "**/vendor"
   - "**/*.{ico,pdf,png}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start
+
 require "goodcheck"
 
 require "minitest/autorun"


### PR DESCRIPTION
Use the `simplecov` gem:
https://github.com/simplecov-ruby/simplecov

Also, the coverage report will be saved and available on GitHub Actions.