### PR TITLE
Improve text reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Goodbye ActiveSupport [#155](https://github.com/sider/goodcheck/pull/155)
 * Fix zero column [#160](https://github.com/sider/goodcheck/pull/160)
+* Improve text reporter [#161](https://github.com/sider/goodcheck/pull/161)
 
 ## 2.6.1 (2020-11-19)
 

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -110,7 +110,7 @@ module Goodcheck
           when DEFAULT_EXCLUSIONS.include?(path.basename.to_s)
             # noop
           when immediate || !excluded?(path)
-            path.children.each do |child|
+            path.children.sort.each do |child|
               each_file(child, &block)
             end
           end

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -57,6 +57,8 @@ module Goodcheck
             end
           end
 
+          reporter.summary
+
           issue_reported ? EXIT_MATCH : EXIT_SUCCESS
         end
       end

--- a/lib/goodcheck/reporters/json.rb
+++ b/lib/goodcheck/reporters/json.rb
@@ -44,6 +44,10 @@ module Goodcheck
       def issue(issue)
         issues << issue
       end
+
+      def summary
+        # noop
+      end
     end
   end
 end

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -5,6 +5,8 @@ module Goodcheck
 
       def initialize(stdout:)
         @stdout = stdout
+        @file_count = 0
+        @issue_count = 0
       end
 
       def analysis
@@ -12,6 +14,7 @@ module Goodcheck
       end
 
       def file(path)
+        @file_count += 1
         yield
       end
 
@@ -20,24 +23,48 @@ module Goodcheck
       end
 
       def issue(issue)
+        @issue_count += 1
+
+        message = issue.rule.message.lines.first.chomp
+
         if issue.location
           start_line = issue.location.start_line
-          start_column_index = issue.location.start_column - 1
+          start_column = issue.location.start_column
+          start_column_index = start_column - 1
           line = issue.buffer.line(start_line)
           column_size = if issue.location.one_line?
-                         issue.location.column_size
-                       else
-                         line.bytesize
-                       end
-          colored_line = line.byteslice(0, start_column_index) +
-                         Rainbow(line.byteslice(start_column_index, column_size)).red +
-                         line.byteslice(start_column_index + column_size, line.bytesize)
-          stdout.puts "#{issue.path}:#{start_line}:#{colored_line.chomp}:\t#{issue.rule.message.lines.first.chomp}"
+                          issue.location.column_size
+                        else
+                          line.bytesize - 1
+                        end
+          stdout.puts "#{Rainbow(issue.path).cyan}:#{start_line}:#{start_column}: #{message}"
+          stdout.puts line.chomp
+          stdout.puts (" " * start_column_index) + Rainbow("^" + "~" * (column_size - 1)).yellow
         else
-          line = issue.buffer.line(1)&.chomp
-          line = line ? Rainbow(line).red : '-'
-          stdout.puts "#{issue.path}:-:#{line}:\t#{issue.rule.message.lines.first.chomp}"
+          stdout.puts "#{Rainbow(issue.path).cyan}:-:-: #{message}"
         end
+      end
+
+      def summary
+        files = case @file_count
+                when 0
+                  "no files"
+                when 1
+                  "1 file"
+                else
+                  "#{@file_count} files"
+                end
+        issues = case @issue_count
+                 when 0
+                   Rainbow("no issues").green
+                 when 1
+                   Rainbow("1 issue").red
+                 else
+                   Rainbow("#{@issue_count} issues").red
+                 end
+
+        stdout.puts ""
+        stdout.puts "#{files} inspected, #{issues} detected"
       end
     end
   end

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -35,7 +35,7 @@ module Goodcheck
           column_size = if issue.location.one_line?
                           issue.location.column_size
                         else
-                          line.bytesize - 1
+                          line.bytesize - start_column
                         end
           stdout.puts "#{Rainbow(issue.path).cyan}:#{start_line}:#{start_column}: #{message}"
           stdout.puts line.chomp

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -354,10 +354,10 @@ EOF
 
         assert_equal 2, check.run
         assert_equal <<OUT, stdout.string
-utf_8.txt:1:10: Foo
+euc_jp.txt:1:10: Foo
 吾輩は猫である。
          ^~~
-euc_jp.txt:1:10: Foo
+utf_8.txt:1:10: Foo
 吾輩は猫である。
          ^~~
 
@@ -474,15 +474,15 @@ EOF
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname(".")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
           assert_equal <<OUT, stdout.string
+.file:1:1: Foo
+foo
+^~~
 goodcheck.yml:2:9: Foo
   - id: foo
         ^~~
 goodcheck.yml:4:14: Foo
     pattern: foo
              ^~~
-.file:1:1: Foo
-foo
-^~~
 
 2 files inspected, 3 issues detected
 OUT
@@ -494,15 +494,15 @@ OUT
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("."), Pathname(".file")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
           assert_equal <<OUT, stdout.string
+.file:1:1: Foo
+foo
+^~~
 goodcheck.yml:2:9: Foo
   - id: foo
         ^~~
 goodcheck.yml:4:14: Foo
     pattern: foo
              ^~~
-.file:1:1: Foo
-foo
-^~~
 .file:1:1: Foo
 foo
 ^~~

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -13,9 +13,9 @@ class SmokeTest < Minitest::Test
     TestCaseBuilder.tmpdir do |builder|
       stdout, stderr, status = shell(goodcheck, chdir: builder.path)
 
-      refute_operator status, :success?
+      refute status.success?
       assert_match %r(#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}), stdout
-      assert_equal "", stderr
+      assert_empty stderr
     end
   end
 
@@ -23,7 +23,7 @@ class SmokeTest < Minitest::Test
     TestCaseBuilder.tmpdir do |builder|
       stdout, stderr, status = shell(goodcheck, "foo", chdir: builder.path)
 
-      refute_operator status, :success?
+      refute status.success?
       assert_match %r(#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}), stdout
       assert_match %r(invalid command: foo), stderr
     end
@@ -31,44 +31,55 @@ class SmokeTest < Minitest::Test
 
   def test_help
     TestCaseBuilder.tmpdir do |builder|
-      stdout, _, status = shell(goodcheck, "help", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "help", chdir: builder.path)
 
-      assert_operator status, :success?
+      assert status.success?
       assert_match %r(#{Regexp.escape "Usage: goodcheck <command> [options] [args...]"}), stdout
+      assert_empty stderr
     end
   end
 
   def test_version
     TestCaseBuilder.tmpdir do |builder|
-      stdout, _, status = shell(goodcheck, "version", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "version", chdir: builder.path)
 
-      assert_operator status, :success?
+      assert status.success?
       assert_match %r(#{Regexp.escape "goodcheck #{Goodcheck::VERSION}"}), stdout
+      assert_empty stderr
     end
   end
 
   def test_version_flag
     TestCaseBuilder.tmpdir do |builder|
-      stdout, _, status = shell(goodcheck, "--version", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "--version", chdir: builder.path)
 
-      assert_operator status, :success?
+      assert status.success?
       assert_match %r(#{Regexp.escape "goodcheck #{Goodcheck::VERSION}"}), stdout
+      assert_empty stderr
     end
   end
 
   def test_init
     TestCaseBuilder.tmpdir do |builder|
-      _, _, status = shell(goodcheck, "init", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "init", chdir: builder.path)
       assert status.success?
-      assert_operator builder.config_path, :file?
+      assert_equal <<OUT, stdout
+Wrote goodcheck.yml. ✍️
+OUT
+      assert_empty stderr
+      assert builder.config_path.file?
     end
   end
 
   def test_init_with_config
     TestCaseBuilder.tmpdir do |builder|
-      _, _, status = shell(goodcheck, "init", "--config=hello.yml", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "init", "--config=hello.yml", chdir: builder.path)
       assert status.success?
-      assert_operator builder.path + "hello.yml", :file?
+      assert_equal <<OUT, stdout
+Wrote hello.yml. ✍️
+OUT
+      assert_empty stderr
+      assert builder.path.join("hello.yml").file?
     end
   end
 
@@ -76,15 +87,21 @@ class SmokeTest < Minitest::Test
     TestCaseBuilder.tmpdir do |builder|
       (builder.path + "hello.yml").write("hogehoge")
 
-      _, _, status = shell(goodcheck, "init", "--config=hello.yml", "--force", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "init", "--config=hello.yml", "--force", chdir: builder.path)
       assert status.success?
-      assert_operator builder.path + "hello.yml", :file?
+      assert_equal <<OUT, stdout
+Wrote hello.yml. ✍️
+OUT
+      assert_empty stderr
+      assert builder.path.join("hello.yml").file?
     end
   end
 
   def test_init_and_pass_test
     TestCaseBuilder.tmpdir do |builder|
       _, _, status = shell(goodcheck, "init", chdir: builder.path)
+      assert status.success?
+
       _, _, status = shell(goodcheck, "test", chdir: builder.path)
       assert status.success?
     end
@@ -103,9 +120,11 @@ rules:
       - hoge hoge
 EOF
 
-      _, _, status = shell(goodcheck, "test", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "test", chdir: builder.path)
 
       assert status.success?
+      assert_match %r(Validating rule id uniqueness...), stdout
+      assert_empty stderr
     end
   end
 
@@ -133,11 +152,17 @@ EOF
 <h1>Foo bar Baz</h1>
 EOF
 
-      stdout, _, status = shell(goodcheck, "check", ".", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "check", ".", chdir: builder.path)
 
       refute status.success?
-      assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout
-      refute_match %r(app/views/welcome/index\.html\.erb:1:), stdout
+      assert_equal <<OUT, stdout
+app/models/user.rb:2:15: Foo
+  belongs_to :foo
+              ^~~
+
+2 files inspected, 1 issue detected
+OUT
+      assert_empty stderr
     end
   end
 
@@ -164,7 +189,7 @@ EOF
 <h1>Foo Bar Baz</h1>
 EOF
 
-      stdout, _, status = shell(goodcheck, "check", "--format=json", ".", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "check", "--format=json", ".", chdir: builder.path)
 
       refute status.success?
       assert_equal [{
@@ -179,6 +204,7 @@ EOF
                       message: "Foo",
                       justifications: []
                     }], JSON.parse(stdout, symbolize_names: true)
+      assert_empty stderr
     end
   end
 
@@ -205,10 +231,17 @@ EOF
 <h1>Foo Bar Baz</h1>
 EOF
 
-      stdout, _, status = shell(goodcheck, "check", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "check", chdir: builder.path)
 
       refute status.success?
-      assert_match %r(app/models/user\.rb:2:  belongs_to :foo:\tFoo), stdout
+      assert_equal <<OUT, stdout
+app/models/user.rb:2:15: Foo
+  belongs_to :foo
+              ^~~
+
+2 files inspected, 1 issue detected
+OUT
+      assert_empty stderr
     end
   end
 
@@ -226,7 +259,7 @@ rules:
     message: Bar
     pattern:
       - regexp: bar
-        case_insensitive: true
+        case_sensitive: false
     glob: "**/*.html.erb"
 EOF
 
@@ -240,11 +273,17 @@ EOF
 <h1>Foo Bar Baz</h1>
 EOF
 
-      stdout, _, status = shell(goodcheck, "check", "-R", "bar", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "check", "-R", "bar", chdir: builder.path)
 
       refute status.success?
-      refute_match %r(app/models/user\.rb), stdout
-      assert_match %r(app/views/welcome/index\.html\.erb), stdout
+      assert_equal <<OUT, stdout
+app/views/welcome/index.html.erb:1:9: Bar
+<h1>Foo Bar Baz</h1>
+        ^~~
+
+2 files inspected, 1 issue detected
+OUT
+      assert_empty stderr
     end
   end
 
@@ -273,7 +312,7 @@ EOF
       stdout, stderr, status = shell(goodcheck, "check", "--help", chdir: builder.path)
 
       assert status.success?
-      assert_equal <<-HELP, stdout
+      assert_equal <<HELP, stdout
 Usage: goodcheck check [options] paths...
     -c, --config=CONFIG              Configuration file path [default: 'goodcheck.yml']
     -v, --verbose                    Set log level to verbose
@@ -283,7 +322,7 @@ Usage: goodcheck check [options] paths...
         --format=<text|json>         Output format [default: 'text']
         --version                    Print version
     -h, --help                       Show help and quit
-      HELP
+HELP
       assert_empty stderr
     end
   end
@@ -302,33 +341,37 @@ rules:
     message: Bar
     pattern:
       - regexp: bar
-        case_insensitive: true
+        case_sensitive: false
     glob: "**/*.html.erb"
 EOF
 
-      stdout, _, status = shell(goodcheck, "pattern", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "pattern", chdir: builder.path)
 
       assert status.success?
       assert_match "sample.foo", stdout
       assert_match "sample.bar", stdout
+      assert_empty stderr
 
-      stdout, _, status = shell(goodcheck, "pattern", "sample.foo", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "pattern", "sample.foo", chdir: builder.path)
 
       assert status.success?
       assert_match "sample.foo", stdout
       refute_match "sample.bar", stdout
+      assert_empty stderr
 
-      stdout, _, status = shell(goodcheck, "pattern", "sample", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "pattern", "sample", chdir: builder.path)
 
       assert status.success?
       assert_match "sample.foo", stdout
       assert_match "sample.bar", stdout
+      assert_empty stderr
 
-      stdout, _, status = shell(goodcheck, "pattern", "foo", chdir: builder.path)
+      stdout, stderr, status = shell(goodcheck, "pattern", "foo", chdir: builder.path)
 
       assert status.success?
       refute_match "sample.foo", stdout
       refute_match "sample.bar", stdout
+      assert_empty stderr
     end
   end
 end


### PR DESCRIPTION
This change aims to make the `--format=text` output more useful and helpful.

- Add summary about files and issues
- Change the output format like the [Clang style](https://clang.llvm.org/diagnostics.html).

For example:

```console
$ exe/goodcheck check README.md
README.md:7:29: Did you mean "GitHub"?
What if a misspelling like `Github` for `GitHub` can be found automatically?
                            ^~~~~~

1 file inspected, 1 issue detected
```

<img width="901" alt="image" src="https://user-images.githubusercontent.com/473530/100756884-09f49d80-3431-11eb-95f1-f34b899c032d.png">
