### PR TITLE
`goodcheck test` exit with `3` on tests failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD
 
 * `goodcheck test` exit with `3` on tests failed [#168](https://github.com/sider/goodcheck/pull/168)
+  (a potentially breaking change; the command previously exited with `1`)
 
 ## 2.7.0 (2020-12-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* `goodcheck test` exit with `3` on tests failed [#168](https://github.com/sider/goodcheck/pull/168)
+
 ## 2.7.0 (2020-12-02)
 
 * Goodbye ActiveSupport [#155](https://github.com/sider/goodcheck/pull/155)

--- a/docusaurus/docs/commands.md
+++ b/docusaurus/docs/commands.md
@@ -29,12 +29,6 @@ Available options are:
 * `--debug` to print all debug messages
 * `--force` to ignore downloaded caches
 
-The `check` command exits with:
-
-* `0` when it does not find any matching text fragment
-* `1` when it finds some error
-* `2` when it finds some matching text
-
 You can check its exit status to identify if the tool finds some pattern or not.
 
 ## `goodcheck test [options]`
@@ -67,3 +61,12 @@ An available option is:
 ## `goodcheck help`
 
 The `help` command prints the full help text.
+
+## Exit status
+
+The `goodcheck` command exits with the status:
+
+* `0` when it succeeds or does not find any matching text fragment
+* `1` when it encounters an fatal error
+* `2` when it finds some matching text
+* `3` when it finds some test failure

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -15,8 +15,6 @@ module Goodcheck
       include HomePath
       include ExitStatus
 
-      EXIT_MATCH = 2
-
       def initialize(config_path:, rules:, targets:, reporter:, stderr:, home_path:, force_download:)
         @config_path = config_path
         @rules = rules

--- a/lib/goodcheck/commands/config_loading.rb
+++ b/lib/goodcheck/commands/config_loading.rb
@@ -1,6 +1,8 @@
 module Goodcheck
   module Commands
     module ConfigLoading
+      include ExitStatus
+
       class ConfigFileNotFound < Error
         attr_reader :path
 
@@ -31,20 +33,20 @@ module Goodcheck
           yield
         rescue ConfigFileNotFound => exn
           stderr.puts "Configuration file not found: #{exn.path}"
-          1
+          EXIT_ERROR
         rescue Psych::Exception => exn
           stderr.puts "Unexpected error happens while loading YAML file: #{exn.inspect}"
           exn.backtrace.each do |trace_loc|
             stderr.puts "  #{trace_loc}"
           end
-          1
+          EXIT_ERROR
         rescue StrongJSON::Type::TypeError, StrongJSON::Type::UnexpectedAttributeError => exn
           stderr.puts "Invalid config: #{exn.message}"
           stderr.puts StrongJSON::ErrorReporter.new(path: exn.path).to_s
-          1
+          EXIT_ERROR
         rescue Errno::ENOENT => exn
           stderr.puts "#{exn}"
-          1
+          EXIT_ERROR
         end
       end
     end

--- a/lib/goodcheck/commands/test.rb
+++ b/lib/goodcheck/commands/test.rb
@@ -28,8 +28,8 @@ module Goodcheck
             return EXIT_SUCCESS
           end
 
-          validate_rule_uniqueness or return EXIT_ERROR
-          validate_rules or return EXIT_ERROR
+          validate_rule_uniqueness or return EXIT_TEST_FAILED
+          validate_rules or return EXIT_TEST_FAILED
 
           EXIT_SUCCESS
         end

--- a/lib/goodcheck/exit_status.rb
+++ b/lib/goodcheck/exit_status.rb
@@ -2,5 +2,7 @@ module Goodcheck
   module ExitStatus
     EXIT_SUCCESS = 0
     EXIT_ERROR = 1
+    EXIT_MATCH = 2
+    EXIT_TEST_FAILED = 3
   end
 end

--- a/test/test_command_test.rb
+++ b/test/test_command_test.rb
@@ -18,7 +18,6 @@ class TestCommandTest < Minitest::Test
       result = test.run
 
       assert_equal 0, result
-
       assert_equal <<MSG, stdout.string
 No rules.
 MSG
@@ -45,7 +44,6 @@ EOF
       result = test.run
 
       assert_equal 0, result
-
       assert_equal <<MSG, stdout.string
 Validating rule id uniqueness...
   OK!👍
@@ -114,8 +112,7 @@ EOF
       test = Test.new(stdout: stdout, stderr: stderr, config_path: builder.config_path, force_download: nil, home_path: builder.path + "home")
       result = test.run
 
-      assert_equal 1, result
-
+      assert_equal 3, result
       assert_equal <<MSG, stdout.string
 Validating rule id uniqueness...
   Found 1 duplication.😞
@@ -141,7 +138,7 @@ EOF
       test = Test.new(stdout: stdout, stderr: stderr, config_path: builder.config_path, force_download: nil, home_path: builder.path + "home")
       result = test.run
 
-      assert_equal 1, result
+      assert_equal 3, result
       assert_equal <<MSG, stdout.string
 Validating rule id uniqueness...
   OK!👍
@@ -173,7 +170,7 @@ EOF
       test = Test.new(stdout: stdout, stderr: stderr, config_path: builder.config_path, force_download: nil, home_path: builder.path + "home")
       result = test.run
 
-      assert_equal 1, result
+      assert_equal 3, result
       assert_equal <<MSG, stdout.string
 Validating rule id uniqueness...
   OK!👍
@@ -190,6 +187,19 @@ Failed rules:
 
 Tested 1 rule, 0 successes, 1 failure
 MSG
+    end
+  end
+
+  def test_invalid_config
+    with_config(<<EOF) do |builder|
+rule:
+EOF
+      test = Test.new(stdout: stdout, stderr: stderr, config_path: builder.config_path, force_download: nil, home_path: builder.path + "home")
+      result = test.run
+
+      assert_equal 1, result
+      assert_empty stdout.string
+      assert_match %r(Invalid config:), stderr.string
     end
   end
 


### PR DESCRIPTION
I think it better to add a new status to ensure the consistency through all the sub commands.

Close #116

NOTE: This is a potentially breaking change. Previously, the `goodcheck test` command exited with `1`, not `3`.