### PR TITLE
Drop support of Ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Drop support of Ruby 2.4 (**breaking**) [#169](https://github.com/sider/goodcheck/pull/169)
+
 ## 2.7.0 (2020-12-02)
 
 * Goodbye ActiveSupport [#155](https://github.com/sider/goodcheck/pull/155)

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", ">= 13.0"


### PR DESCRIPTION
Ruby 2.4 has reached EOL already on April 2020.
See <https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/>