### PR TITLE
Use `YAML.safe_load` instead of `YAML.load`

### DIFF
--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -239,7 +239,7 @@ module Goodcheck
       Goodcheck.logger.info "Importing rules from #{import}"
 
       import_loader.load(import) do |content|
-        json = JSON.parse(JSON.dump(YAML.load(content, filename: import)), symbolize_names: true)
+        json = JSON.parse(JSON.dump(YAML.safe_load(content, filename: import)), symbolize_names: true)
 
         Schema.rules.coerce json
         load_rules(rules, json)

--- a/test/init_command_test.rb
+++ b/test/init_command_test.rb
@@ -14,7 +14,7 @@ class InitCommandTest < Minitest::Test
 
         assert_match %r(Wrote goodcheck\.yml), stdout.string
         assert_operator Pathname("goodcheck.yml"), :file?
-        YAML.load(Pathname("goodcheck.yml").read)
+        YAML.safe_load(Pathname("goodcheck.yml").read)
       end
     end
   end
@@ -29,7 +29,7 @@ class InitCommandTest < Minitest::Test
         assert_equal 1, init.run
         assert_match %r(goodcheck\.yml already exists\.), stderr.string
 
-        assert_equal({ "rules" => [] }, YAML.load(Pathname("goodcheck.yml").read))
+        assert_equal({ "rules" => [] }, YAML.safe_load(Pathname("goodcheck.yml").read))
       end
     end
   end
@@ -43,7 +43,7 @@ class InitCommandTest < Minitest::Test
 
         assert_equal 0, init.run
         assert_match %r(Wrote goodcheck\.yml), stdout.string
-        refute_equal({ "rules" => [] }, YAML.load(Pathname("goodcheck.yml").read))
+        refute_equal({ "rules" => [] }, YAML.safe_load(Pathname("goodcheck.yml").read))
       end
     end
   end


### PR DESCRIPTION
Follow-up of PR #164

See also:
- https://ruby-doc.org/stdlib/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
- https://ruby-doc.org/stdlib/libdoc/psych/rdoc/Psych.html#safe_load-method
- https://ruby-doc.org/stdlib/libdoc/psych/rdoc/Psych.html#load-method
- https://sider.review/gh/repos/112739662/branches/master/commits/6a19c5be34a1ecf651b7c15b5460691a5e7dee62?tools%5B%5D=rubocop&rules%5B%5D=Security%2FYAMLLoad