### PR TITLE
Refactor testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,11 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake
+        env:
+          TESTOPT: '--verbose'
+          COVERAGE: ${{ matrix.ruby == '3.0' }}
       - uses: actions/upload-artifact@v2
-        if: ${{ always() && matrix.ruby == '3.0' }}
+        if: ${{ hashFiles('coverage/index.html') != '' }}
         with:
           name: coverage
           path: coverage/

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "minitest", ">= 5.0"
-  spec.add_development_dependency "minitest-reporters", ">= 1.4"
   spec.add_development_dependency "simplecov", ">= 0.18"
 
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,11 @@
-require "simplecov"
-SimpleCov.start
+if ENV["COVERAGE"] == "true"
+  require "simplecov"
+  SimpleCov.start
+end
 
 require "goodcheck"
 
 require "minitest/autorun"
-require "minitest/reporters"
-Minitest::Reporters.use!
 
 require_relative "test_case_builder"
 require "open3"


### PR DESCRIPTION
- Remove the `minitest-reporters` gem, which seems redundant.
- Enable the coverage conditionally, not always.