### PR TITLE
Fix importing error with extended glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update `psych` requirement allowing 4.0 [#183](https://github.com/sider/goodcheck/pull/183)
 * Improve output error message on RegexpError [#188](https://github.com/sider/goodcheck/pull/188)
 * Import .tar.gz files [#190](https://github.com/sider/goodcheck/pull/190)
+* Fix importing error with extended glob [#194](https://github.com/sider/goodcheck/pull/194)
 
 ## 2.7.0 (2020-12-02)
 

--- a/lib/goodcheck/import_loader.rb
+++ b/lib/goodcheck/import_loader.rb
@@ -32,10 +32,10 @@ module Goodcheck
 
     def load(name, &block)
       uri = begin
-              URI.parse(name)
-            rescue URI::InvalidURIError
-              nil
-            end
+        URI.parse(name)
+      rescue URI::InvalidURIError
+        nil
+      end
 
       case uri&.scheme
       when nil

--- a/lib/goodcheck/import_loader.rb
+++ b/lib/goodcheck/import_loader.rb
@@ -31,9 +31,13 @@ module Goodcheck
     end
 
     def load(name, &block)
-      uri = URI.parse(name)
+      uri = begin
+              URI.parse(name)
+            rescue URI::InvalidURIError
+              nil
+            end
 
-      case uri.scheme
+      case uri&.scheme
       when nil
         load_file name, &block
       when "file"

--- a/test/import_loader_test.rb
+++ b/test/import_loader_test.rb
@@ -56,12 +56,12 @@ EOF
   message: Message
 EOF
       (path + ".rules").mkpath
-      (path + ".rules" + "bar.yml").write rule_content_2
+      (path + ".rules" + "bar.yaml").write rule_content_2
 
       loader = Goodcheck::ImportLoader.new(cache_path: cache_path, force_download: false, config_path: path + "goodcheck.yml")
 
       loaded_content = []
-      loader.load("**/*.yml") do |content|
+      loader.load("**/*.{yml,yaml}") do |content|
         loaded_content << content
       end
 


### PR DESCRIPTION
For example:

```yaml
# goodcheck.yml
import:
  - "lib/**/*.{yml,yaml}"
```

```console
$ exe/goodcheck test
#<URI::InvalidURIError: bad URI(is not URI?): "lib/**/*.{yml,yaml}">
...
```