### PR TITLE
Introduce `exclude_binary` option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: ${{ matrix.ruby != '2.5' }} # https://github.com/sider/goodcheck/pull/195/checks?check_run_id=2735777166#step:3:70
+      - run: gem update --system && bundle install
+        if: ${{ matrix.ruby == '2.5' }}
       - run: bundle exec rake
         env:
           TESTOPT: '--verbose'

--- a/docusaurus/docs/configuration.md
+++ b/docusaurus/docs/configuration.md
@@ -346,8 +346,8 @@ exclude:
 exclude_binary: true
 ```
 
-- The value of `exclude` can be one or more strings, representing an excluded directory or a glob pattern for excluded files.
-- The value of `exclude_binary` can be a boolean. If enabled, Goodcheck will exclude files considered as *binary*. Defaults to `false`.
+- `exclude` - allows one or more strings, representing an excluded directory or a glob pattern for excluded files.
+- `exclude_binary` - allows a boolean. Defaults to `false`. If enabled, Goodcheck will exclude files considered as *binary*.
   For example, files like `foo.png` or `bar.zip` are considered as *binary*.
 
 ## Disabling rules with inline comments

--- a/docusaurus/docs/configuration.md
+++ b/docusaurus/docs/configuration.md
@@ -335,16 +335,20 @@ The cache expires in 3 minutes.
 
 ## Excluding files
 
-`goodcheck.yml` can have an optional `exclude` attribute.
+`goodcheck.yml` can have an optional `exclude` or `exclude_binary` attribute, which allows you to exclude any files.
 
 ```yaml
 exclude:
   - node_modules
   - vendor
   - assets/**/*.png
+
+exclude_binary: true
 ```
 
-The value of `exclude` can be a string or an array of strings representing the glob pattern for excluded files.
+- The value of `exclude` can be one or more strings, representing an excluded directory or a glob pattern for excluded files.
+- The value of `exclude_binary` can be a boolean. If enabled, Goodcheck will exclude files considered as *binary*. Defaults to `false`.
+  For example, files like `foo.png` or `bar.zip` are considered as *binary*.
 
 ## Disabling rules with inline comments
 

--- a/goodcheck.gemspec
+++ b/goodcheck.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", ">= 5.0"
   spec.add_development_dependency "simplecov", ">= 0.18"
 
+  spec.add_runtime_dependency "marcel", ">= 1.0", "< 2.0"
   spec.add_runtime_dependency "strong_json", ">= 1.1", "< 2.2"
   spec.add_runtime_dependency "rainbow", ">= 3.0", "< 4.0"
   spec.add_runtime_dependency "psych", ">= 3.1", "< 5.0" # NOTE: Needed for old Ruby versions (<= 2.5)

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -13,6 +13,5 @@ exclude:
   - "**/coverage"
   - "**/node_modules"
   - "**/vendor"
+  - "**/*.{ico,pdf,png}"
   - "**/yarn.lock"
-
-exclude_binary: true

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -13,5 +13,6 @@ exclude:
   - "**/coverage"
   - "**/node_modules"
   - "**/vendor"
-  - "**/*.{ico,pdf,png}"
   - "**/yarn.lock"
+
+exclude_binary: true

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -127,7 +127,7 @@ module Goodcheck
       end
 
       def excluded?(path)
-        config.exclude_paths.any? {|pattern| path.fnmatch?(pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
+        config.exclude_path?(path)
       end
     end
   end

--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -3,20 +3,20 @@ module Goodcheck
     DEFAULT_EXCLUDE_BINARY = false
 
     # https://www.iana.org/assignments/media-types/media-types.xhtml
-    BINARY_MIME_TYPES = Set.new(%w[
+    BINARY_MIME_TYPES = %w[
       audio
       font
       image
       model
       multipart
       video
-    ]).freeze
-    BINARY_MIME_FULLTYPES = Set.new(%w[
+    ].to_set.freeze
+    BINARY_MIME_FULLTYPES = %w[
       application/gzip
       application/illustrator
       application/pdf
       application/zip
-    ]).freeze
+    ].to_set.freeze
 
     attr_reader :rules
     attr_reader :exclude_paths

--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -1,11 +1,32 @@
 module Goodcheck
   class Config
+    DEFAULT_EXCLUDE_BINARY = false
+
+    # https://www.iana.org/assignments/media-types/media-types.xhtml
+    BINARY_MIME_TYPES = Set.new(%w[
+      audio
+      font
+      image
+      model
+      multipart
+      video
+    ]).freeze
+    BINARY_MIME_FULLTYPES = Set.new(%w[
+      application/gzip
+      application/illustrator
+      application/pdf
+      application/zip
+    ]).freeze
+
     attr_reader :rules
     attr_reader :exclude_paths
+    attr_reader :exclude_binary
+    alias exclude_binary? exclude_binary
 
-    def initialize(rules:, exclude_paths:)
+    def initialize(rules:, exclude_paths:, exclude_binary: DEFAULT_EXCLUDE_BINARY)
       @rules = rules
       @exclude_paths = exclude_paths
+      @exclude_binary = exclude_binary.nil? ? DEFAULT_EXCLUDE_BINARY : exclude_binary
     end
 
     def each_rule(filter:, &block)
@@ -42,6 +63,41 @@ module Goodcheck
         end
       else
         enum_for(:rules_for_path, path, rules_filter: rules_filter)
+      end
+    end
+
+    def exclude_path?(path)
+      excluded = exclude_paths.any? do |pattern|
+        path.fnmatch?(pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB)
+      end
+
+      return true if excluded
+      return excluded unless exclude_binary?
+      return excluded unless path.file?
+
+      exclude_file_by_mime_type?(path)
+    end
+
+    private
+
+    def exclude_file_by_mime_type?(file)
+      # NOTE: Lazy load to save memory
+      require "marcel"
+
+      fulltype = Marcel::MimeType.for(file)
+      type, subtype = fulltype.split("/")
+
+      case
+      when subtype.end_with?("+xml") # e.g. "image/svg+xml"
+        false
+      when BINARY_MIME_TYPES.include?(type)
+        Goodcheck.logger.debug "Exclude file: #{file} (#{fulltype})"
+        true
+      when BINARY_MIME_FULLTYPES.include?(fulltype)
+        Goodcheck.logger.debug "Exclude file: #{file} (#{fulltype})"
+        true
+      else
+        false
       end
     end
   end

--- a/lib/goodcheck/config_loader.rb
+++ b/lib/goodcheck/config_loader.rb
@@ -186,15 +186,14 @@ module Goodcheck
                       })
 
       let :rules, array(rule)
-
-      let :import_target, string
-      let :imports, array(import_target)
+      let :imports, array(string)
       let :exclude, array_or(string)
 
       let :config, object(
         rules: optional(rules),
         import: optional(imports),
-        exclude: optional(exclude)
+        exclude: optional(exclude),
+        exclude_binary: boolean?
       )
     end
 
@@ -224,9 +223,11 @@ module Goodcheck
         load_import rules, import
       end
 
-      exclude_paths = Array(content[:exclude])
-
-      Config.new(rules: rules, exclude_paths: exclude_paths)
+      Config.new(
+        rules: rules,
+        exclude_paths: Array(content[:exclude]),
+        exclude_binary: content[:exclude_binary]
+      )
     end
 
     def load_rules(rules, array)

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -264,7 +264,8 @@ Where:
   config = {
     "rules": optional(rules),
     "import": optional(imports),
-    "exclude": optional(exclude)
+    "exclude": optional(exclude),
+    "exclude_binary": optional(boolean)
   }
   positive_rule = {
     "id": string,

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -82,8 +82,8 @@ class ConfigTest < Minitest::Test
       config = Config.new(rules: [], exclude_paths: [], exclude_binary: true)
 
       assert config.exclude_path?(Pathname(__dir__) / "fixtures" / "goodcheck-test-rules.tar.gz")
-      refute config.exclude_path? file.("a.rb")
-      refute config.exclude_path? file.("a.svg")
+      refute config.exclude_path? file.call("a.rb")
+      refute config.exclude_path? file.call("a.svg")
     end
   end
 end


### PR DESCRIPTION
This change introduces a new option for `goodcheck.yml`: `exclude_binary`.

Usage:

```yaml
# goodcheck.yml

exclude_binary: true    # default: false
```

This change uses the `marcel` gem to detect if a file is binary or not.
See <https://github.com/rails/marcel>