### PR TITLE
Retry HTTP GET request on importing rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Retry HTTP GET request on importing rules [#197](https://github.com/sider/goodcheck/pull/197)
+
 ## 3.0.0 (2021-06-14)
 
 Breaking changes:

--- a/test/import_loader_test.rb
+++ b/test/import_loader_test.rb
@@ -273,9 +273,9 @@ EOF
   def test_http_get_failed
     loader = Goodcheck::ImportLoader.new(cache_path: nil, force_download: false, config_path: nil)
 
-    error = assert_raises RuntimeError do
+    error = assert_raises Goodcheck::ImportLoader::HTTPGetError do
       loader.http_get('https://github.com/sider/goodcheck/not_found.txt')
     end
-    assert_includes error.message, 'Error: HTTP GET "https://github.com/sider/goodcheck/not_found.txt"'
+    assert_equal 'HTTP GET https://github.com/sider/goodcheck/not_found.txt => 404 Not Found', error.message
   end
 end


### PR DESCRIPTION
This change aims to prevent the following error:

```
#<RuntimeError: Error: HTTP GET #<URI::HTTPS https://github.com/sider/goodcheck-rules/archive/refs/tags/v0.0.1.tar.gz> #<Net::HTTPTooManyRequests 429 Too Many Requests readbody=true>>
```