### PR TITLE
Retry importing on Net::OpenTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Retry importing on Net::OpenTimeout [#202](https://github.com/sider/goodcheck/pull/202)
+
 ## 3.0.1 (2021-06-14)
 
 * Retry HTTP GET request on importing rules [#197](https://github.com/sider/goodcheck/pull/197)

--- a/lib/goodcheck/import_loader.rb
+++ b/lib/goodcheck/import_loader.rb
@@ -148,7 +148,7 @@ module Goodcheck
         else
           raise HTTPGetError.new(res)
         end
-      rescue HTTPGetError => exn
+      rescue Net::OpenTimeout, HTTPGetError => exn
         if retry_count < max_retry_count && exn.error_response?
           retry_count += 1
           Goodcheck.logger.info "#{retry_count} retry HTTP GET #{exn.response.uri} due to '#{exn.response.code} #{exn.response.message}'..."


### PR DESCRIPTION
```
#<Net::OpenTimeout: execution expired>
  /usr/local/lib/ruby/2.7.0/net/http.rb:960:in `initialize'
  /usr/local/lib/ruby/2.7.0/net/http.rb:960:in `open'
  /usr/local/lib/ruby/2.7.0/net/http.rb:960:in `block in connect'
  /usr/local/lib/ruby/2.7.0/timeout.rb:105:in `timeout'
  /usr/local/lib/ruby/2.7.0/net/http.rb:958:in `connect'
  /usr/local/lib/ruby/2.7.0/net/http.rb:943:in `do_start'
  /usr/local/lib/ruby/2.7.0/net/http.rb:932:in `start'
  /usr/local/lib/ruby/2.7.0/net/http.rb:606:in `start'
  /usr/local/lib/ruby/2.7.0/net/http.rb:481:in `get_response'
  /home/analyzer_runner/ruby/gems/goodcheck-3.0.1/lib/goodcheck/import_loader.rb:141:in `http_get'
  /home/analyzer_runner/ruby/gems/goodcheck-3.0.1/lib/goodcheck/import_loader.rb:114:in `load_http'
```

Related to #197