### PR TITLE
Fix HTTP GET retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Fix HTTP GET retrying [#203](https://github.com/sider/goodcheck/pull/203)
+
 ## 3.0.2 (2021-06-23)
 
 * Retry importing on Net::OpenTimeout [#202](https://github.com/sider/goodcheck/pull/202)

--- a/test/import_loader_test.rb
+++ b/test/import_loader_test.rb
@@ -278,4 +278,14 @@ EOF
     end
     assert_equal 'HTTP GET https://github.com/sider/goodcheck/not_found.txt => 404 Not Found', error.message
   end
+
+  def test_http_get_open_timeout
+    loader = Goodcheck::ImportLoader.new(cache_path: nil, force_download: false, config_path: nil)
+
+    Net::HTTP.stub :get_response, ->(_) { raise Net::OpenTimeout } do
+      assert_raises Net::OpenTimeout do
+        loader.http_get('https://github.com/sider/goodcheck')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change aims to fix the following error:

```
NoMethodError: undefined method `error_response?' for #<Net::OpenTimeout: execution expired>
```