### PR TITLE
Improve coloring for text format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Improve coloring for text format [#208](https://github.com/sider/goodcheck/pull/208)
+
 ## 3.0.3 (2021-06-25)
 
 * Fix HTTP GET retrying [#203](https://github.com/sider/goodcheck/pull/203)

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -2,6 +2,7 @@ rules:
   - id: sider.goodcheck.error_class
     pattern: StandardError
     glob: "lib/**/*.rb"
+    severity: warning
     message: |
       Use `GoodCheck::Error` instead of `StandardError`.
 

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -25,7 +25,11 @@ module Goodcheck
       def issue(issue)
         @issue_count += 1
 
+        path = Rainbow(issue.path).cyan
         message = issue.rule.message.lines.first.chomp
+        rule = Rainbow("(#{issue.rule.id})").dimgray
+        severity = issue.rule.severity ? Rainbow("[#{issue.rule.severity}]").magenta : ""
+        format = "%<path>s%<location>s %<message>s  %<rule>s  %<severity>s"
 
         if issue.location
           start_line = issue.location.start_line
@@ -37,13 +41,13 @@ module Goodcheck
                         else
                           line.bytesize - start_column
                         end
-          rule = Rainbow("(#{issue.rule.id})").darkgray
-          severity = issue.rule.severity ? Rainbow("[#{issue.rule.severity}]").magenta : ""
-          stdout.puts "#{Rainbow(issue.path).cyan}:#{start_line}:#{start_column}: #{message}  #{rule}  #{severity}".strip
+          location = Rainbow(":#{start_line}:#{start_column}:").dimgray
+          stdout.puts sprintf(format, { path: path, location: location, message: message, rule: rule, severity: severity }).strip
           stdout.puts line.chomp
           stdout.puts (" " * start_column_index) + Rainbow("^" + "~" * (column_size - 1)).yellow
         else
-          stdout.puts "#{Rainbow(issue.path).cyan}:-:-: #{message}"
+          location = Rainbow(":-:-:").dimgray
+          stdout.puts sprintf(format, { path: path, location: location, message: message, rule: rule, severity: severity }).strip
         end
       end
 

--- a/lib/goodcheck/reporters/text.rb
+++ b/lib/goodcheck/reporters/text.rb
@@ -25,7 +25,7 @@ module Goodcheck
       def issue(issue)
         @issue_count += 1
 
-        format_line = ->(line:, column:) {
+        format_line = lambda do |line:, column:|
           format_args = {
             path: Rainbow(issue.path).cyan,
             location: Rainbow(":#{line}:#{column}:").dimgray,
@@ -34,7 +34,7 @@ module Goodcheck
             severity: issue.rule.severity ? Rainbow("[#{issue.rule.severity}]").magenta : ""
           }
           format("%<path>s%<location>s %<message>s  %<rule>s  %<severity>s", format_args).strip
-        }
+        end
 
         if issue.location
           start_line = issue.location.start_line

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -144,7 +144,7 @@ EOF
 
         assert_equal 2, check.run
         assert_equal <<OUT, stdout.string
-package.json:-:-: Foo
+package.json:-:-: Foo  (foo)
 
 2 files inspected, 1 issue detected
 OUT
@@ -758,7 +758,7 @@ EOF
         Check.new(config_path: builder.config_path, rules: [], targets: [Pathname("x.js")], reporter: reporter, stderr: stderr, force_download: false, home_path: builder.path + "home").tap do |check|
           assert_equal 2, check.run
           assert_equal <<OUT, stdout.string
-x.js:-:-: Use *strict mode* if possible.
+x.js:-:-: Use *strict mode* if possible.  (strict-mode)
 
 1 file inspected, 1 issue detected
 OUT


### PR DESCRIPTION
- Use `dimgray` for a location and rule to clarify a path and message.
- Output a rule and severity for messages without a pattern.

For example:

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/473530/125709125-7537eeb8-917f-421b-b85a-bed51854761d.png">
